### PR TITLE
build: Add publish workflow

### DIFF
--- a/.github/workflows/publish-admin-ui-components.yml
+++ b/.github/workflows/publish-admin-ui-components.yml
@@ -1,0 +1,48 @@
+name: Publish admin-ui-components to NPM Registry
+
+on:
+  push:
+    branches:
+      - master
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Install dependencies
+        run: yarn install
+      - name: Test
+        run: yarn ci
+  publish:
+    runs-on: ubuntu-latest
+    needs: test
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install dependencies
+        run: yarn install
+      - name: Set github email
+        run: echo '::set-env name=GITHUB_EMAIL::$(git show -s --format='%ae' HEAD)'
+      - name: Set github name
+        run: echo '::set-env name=GITHUB_NAME::$(git show -s --format='%an' HEAD)'
+      - name: Configure Git User
+        run: |
+          git config user.name "${{ env.GITHUB_NAME }}"
+          git config user.email "${{ env.GITHUB_EMAIL}}"
+      - name: Bump version (prerelease)
+        run: |
+          yarn version --minor
+          git push --all
+      - name: Publish ui-components
+        run: yarn publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.YARN_TOKEN }}


### PR DESCRIPTION
The publish workflow will execute on ever merge to `master`.
The workflow will bump the `patch` version (3rd number).
For example 1.2.3 -> 1.2.4

Since this is mostly internal-facing work, there's no need to
carefully have release alphas or pre-release numbers.

Every commit on master will have its own specific version number.