### PR TITLE
Add ActivateStatementDiagnosticsModal component

### DIFF
--- a/src/activateStatementDiagnosticsModal/activateStatementDiagnosticsModal.tsx
+++ b/src/activateStatementDiagnosticsModal/activateStatementDiagnosticsModal.tsx
@@ -1,0 +1,61 @@
+import React, { useState, useCallback, useImperativeHandle } from "react";
+
+import { Modal } from "../modal";
+import { Anchor } from "../anchor";
+import { Text } from "../text";
+
+export interface ActivateDiagnosticsModalProps {
+  activate: (statement: string) => void;
+  refreshDiagnosticsReports: () => void;
+  learnMoreUrl: string;
+}
+
+export interface ActivateDiagnosticsModalRef {
+  showModalFor: (statement: string) => void;
+}
+
+export const ActivateStatementDiagnosticsModal = (
+  { activate, learnMoreUrl }: ActivateDiagnosticsModalProps,
+  ref: React.RefObject<ActivateDiagnosticsModalRef>,
+) => {
+  const [visible, setVisible] = useState(false);
+  const [statement, setStatement] = useState<string>();
+
+  const onOkHandler = useCallback(() => {
+    activate(statement);
+    setVisible(false);
+  }, [activate, statement]);
+
+  const onCancelHandler = useCallback(() => setVisible(false), []);
+
+  useImperativeHandle(ref, () => {
+    return {
+      showModalFor: (forwardStatement: string) => {
+        setStatement(forwardStatement);
+        setVisible(true);
+      },
+    };
+  });
+
+  return (
+    <Modal
+      visible={visible}
+      onOk={onOkHandler}
+      onCancel={onCancelHandler}
+      okText="Activate"
+      cancelText="Cancel"
+      title="Activate statement diagnostics"
+    >
+      <Text>
+        When you activate statement diagnostics, CockroachDB will wait for the
+        next query that matches this statement fingerprint.
+      </Text>
+      <p />
+      <Text>
+        A download button will appear on the statement list and detail pages
+        when the query is ready. The download will include EXPLAIN plans, table
+        statistics, and traces. <Anchor href={learnMoreUrl}>Learn more</Anchor>
+      </Text>
+    </Modal>
+  );
+};

--- a/src/activateStatementDiagnosticsModal/index.ts
+++ b/src/activateStatementDiagnosticsModal/index.ts
@@ -1,0 +1,1 @@
+export * from "./activateStatementDiagnosticsModal";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./empty";
 export * from "./sortabletable";
+export * from "./activateStatementDiagnosticsModal";

--- a/src/modal/index.ts
+++ b/src/modal/index.ts
@@ -1,0 +1,1 @@
+export * from "./modal";

--- a/src/modal/modal.module.scss
+++ b/src/modal/modal.module.scss
@@ -1,0 +1,29 @@
+@import '../core/index.module';
+
+.crl-modal {
+  .ant-modal-footer {
+    border-top: none;
+    padding: 0;
+  }
+
+  .ant-modal-header {
+    border-bottom: none;
+    padding-top: unset;
+    padding-bottom: unset;
+  }
+
+  .ant-modal-content {
+    padding: $spacing-medium;
+    box-shadow: 0px 0px 1px rgba(71, 88, 114, 0.47);
+    border-radius: 5px;
+    min-width: 560px;
+  }
+
+  &__close-icon {
+    color: $colors--neutral-7;
+    margin: $spacing-medium $spacing-medium $spacing-medium-small $spacing-medium-small;
+    font-size: $font-size--large;
+    line-height: $spacing-smaller;
+    font-weight: $font-weight--extra-bold;
+  }
+}

--- a/src/modal/modal.tsx
+++ b/src/modal/modal.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import AntModal from "antd/lib/modal";
+import { Button } from "../button";
+import { Text, TextTypes } from "../text";
+import "./modal.module.scss";
+
+export interface ModalProps {
+  title?: string;
+  onOk?: () => void;
+  onCancel?: () => void;
+  okText?: string;
+  cancelText?: string;
+  visible: boolean;
+}
+
+export const Modal: React.FC<ModalProps> = ({
+  children,
+  onOk,
+  onCancel,
+  okText,
+  cancelText,
+  visible,
+  title,
+}) => {
+  return (
+    <AntModal
+      title={title && <Text textType={TextTypes.Heading3}>{title}</Text>}
+      className="crl-modal"
+      visible={visible}
+      closeIcon={
+        <div className="crl-modal__close-icon" onClick={onCancel}>
+          &times;
+        </div>
+      }
+      footer={[
+        <Button onClick={onCancel} type="secondary" key="cancelButton">
+          {cancelText}
+        </Button>,
+        <Button onClick={onOk} type="primary" key="okButton">
+          {okText}
+        </Button>,
+      ]}
+    >
+      {children}
+    </AntModal>
+  );
+};


### PR DESCRIPTION
Related to https://github.com/cockroachdb/cockroach/issues/51422

- Add Modal component as a dependency
- Extended ActivateStatementDiagnosticsModal component with one
more prop - `learnMoreUrl` it is required to provide custom links
per project and avoid dependencies on a predefined list of URLs.