### PR TITLE
Add SortedTable component

### DIFF
--- a/jest.testing.config.js
+++ b/jest.testing.config.js
@@ -5,6 +5,10 @@ module.exports = {
     "\\.(jpg|ico|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "identity-obj-proxy",
     "\\.(css|scss)$": "identity-obj-proxy",
   },
+  "moduleDirectories": [
+    ".",
+    "node_modules"
+  ],
   roots: ["<rootDir>/src"],
   setupFilesAfterEnv: ["jest-enzyme"],
   testEnvironment: "enzyme",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
   "dependencies": {
     "@cockroachlabs/icons": "^0.2.2",
     "@popperjs/core": "^2.4.0",
-    "react-popper": "^2.2.3"
+    "long": "^4.0.0",
+    "react-popper": "^2.2.3",
+    "reselect": "^4.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.3",
@@ -47,8 +49,10 @@
     "@types/enzyme": "^3.10.5",
     "@types/jest": "^25.1.2",
     "@types/lodash": "^4.14.149",
+    "@types/long": "^4.0.1",
     "@types/node": "^13.7.0",
     "@types/react": "^16.9.17",
+    "@types/reselect": "^2.2.0",
     "@types/sinon": "^9.0.4",
     "@typescript-eslint/eslint-plugin": "^2.19.2",
     "@typescript-eslint/parser": "^2.19.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export * from "./empty";
 export * from "./sortabletable";
 export * from "./activateStatementDiagnosticsModal";
 export * from "./pagination";
+export * from "./sortedtable";

--- a/src/sortedtable/index.tsx
+++ b/src/sortedtable/index.tsx
@@ -1,0 +1,1 @@
+export * from "./sortedtable";

--- a/src/sortedtable/sortedtable.spec.tsx
+++ b/src/sortedtable/sortedtable.spec.tsx
@@ -1,0 +1,257 @@
+import React from "react";
+import _ from "lodash";
+import { assert } from "chai";
+import { mount } from "enzyme";
+import * as sinon from "sinon";
+import classNames from "classnames/bind";
+import {
+  SortedTable,
+  ColumnDescriptor,
+  ISortedTablePagination,
+  SortSetting,
+} from "src/index";
+import styles from "src/sortabletable/sortabletable.module.scss";
+
+const cx = classNames.bind(styles);
+
+class TestRow {
+  constructor(public name: string, public value: number) {}
+}
+
+const columns: ColumnDescriptor<TestRow>[] = [
+  {
+    title: "first",
+    cell: tr => tr.name,
+    sort: tr => tr.name,
+  },
+  {
+    title: "second",
+    cell: tr => tr.value.toString(),
+    sort: tr => tr.value,
+    rollup: trs => _.sumBy(trs, tr => tr.value),
+  },
+];
+
+class TestSortedTable extends SortedTable<TestRow> {}
+
+function makeTable(
+  data: TestRow[],
+  sortSetting?: SortSetting,
+  onChangeSortSetting?: (ss: SortSetting) => void,
+  pagination?: ISortedTablePagination,
+) {
+  return mount(
+    <TestSortedTable
+      data={data}
+      sortSetting={sortSetting}
+      onChangeSortSetting={onChangeSortSetting}
+      pagination={pagination}
+      columns={columns}
+    />,
+  );
+}
+
+function makeExpandableTable(data: TestRow[], sortSetting: SortSetting) {
+  return mount(
+    <TestSortedTable
+      data={data}
+      columns={columns}
+      sortSetting={sortSetting}
+      expandableConfig={{
+        expandedContent: testRow => (
+          <div>
+            {testRow.name}={testRow.value}
+          </div>
+        ),
+        expansionKey: testRow => testRow.name,
+      }}
+    />,
+  );
+}
+
+describe("<SortedTable>", function() {
+  it("renders the expected table structure.", function() {
+    const wrapper = makeTable([new TestRow("test", 1)]);
+    assert.lengthOf(wrapper.find("table"), 1, "one table");
+    assert.lengthOf(wrapper.find("thead").find("tr"), 1, "one header row");
+    assert.lengthOf(
+      wrapper.find(`tr.${cx("sort-table__row--header")}`),
+      1,
+      "column header row",
+    );
+    assert.lengthOf(wrapper.find("tbody"), 1, "tbody element");
+  });
+
+  it("correctly uses onChangeSortSetting", function() {
+    const spy = sinon.spy();
+    const wrapper = makeTable([new TestRow("test", 1)], undefined, spy);
+    wrapper
+      .find(`th.${cx("sort-table__cell")}`)
+      .first()
+      .simulate("click");
+    assert.isTrue(spy.calledOnce);
+    assert.deepEqual(spy.getCall(0).args[0], {
+      sortKey: 0,
+      ascending: false,
+    } as SortSetting);
+  });
+
+  it("correctly sorts data based on sortSetting", function() {
+    const data = [
+      new TestRow("c", 3),
+      new TestRow("d", 4),
+      new TestRow("a", 1),
+      new TestRow("b", 2),
+    ];
+    let wrapper = makeTable(data, undefined);
+    const assertMatches = (expected: TestRow[]) => {
+      const rows = wrapper.find("tbody");
+      _.each(expected, (rowData, dataIndex) => {
+        const row = rows.childAt(dataIndex);
+        assert.equal(
+          row.childAt(0).text(),
+          rowData.name,
+          "first columns match",
+        );
+        assert.equal(
+          row.childAt(1).text(),
+          rowData.value.toString(),
+          "second columns match",
+        );
+      });
+    };
+    assertMatches(data);
+    wrapper = makeTable(data, { sortKey: 0, ascending: true });
+    assertMatches(_.sortBy(data, r => r.name));
+    wrapper.setProps({
+      uiSortSetting: { sortKey: 1, ascending: true } as SortSetting,
+    });
+    assertMatches(_.sortBy(data, r => r.value));
+  });
+
+  describe("with expandableConfig", function() {
+    it("renders the expected table structure", function() {
+      const wrapper = makeExpandableTable([new TestRow("test", 1)], undefined);
+      assert.lengthOf(wrapper.find("table"), 1, "one table");
+      assert.lengthOf(wrapper.find("thead").find("tr"), 1, "one header row");
+      assert.lengthOf(
+        wrapper.find(`tr.${cx("sort-table__row--header")}`),
+        1,
+        "column header row",
+      );
+      assert.lengthOf(wrapper.find("tbody"), 1, "tbody element");
+      assert.lengthOf(wrapper.find("tbody tr"), 1, "one body row");
+      assert.lengthOf(
+        wrapper.find("tbody td"),
+        3,
+        "two body cells plus one expansion control cell",
+      );
+      assert.lengthOf(
+        wrapper.find(`td.${cx("sort-table__cell__expansion-control")}`),
+        1,
+        "one expansion control cell",
+      );
+    });
+
+    it("expands and collapses the clicked row", function() {
+      const wrapper = makeExpandableTable([new TestRow("test", 1)], undefined);
+      assert.lengthOf(
+        wrapper.find(`.${cx("sort-table__row--expanded-area")}`),
+        0,
+        "nothing expanded yet",
+      );
+      wrapper
+        .find(`.${cx("sort-table__cell__expansion-control")}`)
+        .simulate("click");
+      const expandedArea = wrapper.find(".sort-table__row--expanded-area");
+      assert.lengthOf(expandedArea, 1, "row is expanded");
+      assert.lengthOf(
+        expandedArea.children(),
+        2,
+        "expanded row contains placeholder and content area",
+      );
+      assert.isTrue(expandedArea.contains(<td />));
+      assert.isTrue(
+        expandedArea.contains(
+          <td className={cx("sort-table__cell")} colSpan={2}>
+            <div>test=1</div>
+          </td>,
+        ),
+      );
+      wrapper
+        .find(`.${cx("sort-table__cell__expansion-control")}`)
+        .simulate("click");
+      assert.lengthOf(
+        wrapper.find(`.${cx("sort-table__row--expanded-area")}`),
+        0,
+        "row collapsed again",
+      );
+    });
+  });
+
+  it("should correctly render rows with pagination and sort settings", function() {
+    const data = [
+      new TestRow("c", 3),
+      new TestRow("d", 4),
+      new TestRow("a", 1),
+      new TestRow("b", 2),
+    ];
+    let wrapper = makeTable(data, undefined, undefined, {
+      current: 1,
+      pageSize: 2,
+    });
+    let rows = wrapper.find("tbody");
+    assert.lengthOf(wrapper.find("tbody tr"), 2, "two body rows");
+    assert.equal(
+      rows
+        .childAt(1)
+        .childAt(0)
+        .text(),
+      "d",
+      "second row column at first page match",
+    );
+
+    wrapper = makeTable(data, undefined, undefined, {
+      current: 2,
+      pageSize: 2,
+    });
+    rows = wrapper.find("tbody");
+    assert.lengthOf(wrapper.find("tbody tr"), 2, "two body rows");
+    assert.equal(
+      rows
+        .childAt(0)
+        .childAt(0)
+        .text(),
+      "a",
+      "first row column at seconds page match",
+    );
+
+    wrapper = makeTable(data, { sortKey: 0, ascending: true }, undefined, {
+      current: 1,
+      pageSize: 2,
+    });
+    rows = wrapper.find("tbody");
+    assert.equal(
+      rows
+        .childAt(1)
+        .childAt(0)
+        .text(),
+      "b",
+      "second row column at first page match",
+    );
+
+    wrapper = makeTable(data, { sortKey: 0, ascending: true }, undefined, {
+      current: 2,
+      pageSize: 2,
+    });
+    rows = wrapper.find("tbody");
+    assert.equal(
+      rows
+        .childAt(0)
+        .childAt(0)
+        .text(),
+      "c",
+      "first row column at seconds page match",
+    );
+  });
+});

--- a/src/sortedtable/sortedtable.tsx
+++ b/src/sortedtable/sortedtable.tsx
@@ -1,0 +1,274 @@
+import React from "react";
+import _ from "lodash";
+import * as Long from "long";
+import { Moment } from "moment";
+import { createSelector } from "reselect";
+import {
+  ExpandableConfig,
+  SortableColumn,
+  SortableTable,
+  SortSetting,
+  EmptyProps,
+} from "src/index";
+
+export interface ISortedTablePagination {
+  current: number;
+  pageSize: number;
+}
+
+/**
+ * ColumnDescriptor is used to describe metadata about an individual column
+ * in a SortedTable.
+ */
+export interface ColumnDescriptor<T> {
+  // Title string that should appear in the header column.
+  title: React.ReactNode;
+  // Function which generates the contents of an individual cell in this table.
+  cell: (obj: T) => React.ReactNode;
+  // Function which returns a value that can be used to sort the collection of
+  // objects. This will be used to sort the table according to the data in
+  // this column.
+  // TODO(vilterp): using an "Ordered" typeclass here would be nice;
+  // not sure how to do that in TypeScript.
+  sort?: (obj: T) => string | number | Long | Moment;
+  // Function that generates a "rollup" value for this column from all objects
+  // in a collection. This is used to display an appropriate "total" value for
+  // each column.
+  rollup?: (objs: T[]) => React.ReactNode;
+  // className to be applied to the td elements in this column.
+  className?: string;
+  titleAlign?: "left" | "right" | "center";
+}
+
+/**
+ * SortedTableProps describes the properties expected by a SortedTable
+ * component.
+ */
+interface SortedTableProps<T> {
+  // The data which should be displayed in the table. This data may be sorted
+  // by this component before display.
+  data: T[];
+  // Description of columns to display.
+  columns: ColumnDescriptor<T>[];
+  // sortSetting specifies how data should be sorted in this table, by
+  // specifying a column id and a direction.
+  sortSetting: SortSetting;
+  // Callback that should be invoked when the user want to change the sort
+  // setting.
+  onChangeSortSetting?: { (ss: SortSetting): void };
+  // className to be applied to the table element.
+  className?: string;
+  // A function that returns the class to apply to a given row.
+  rowClass?: (obj: T) => string;
+
+  // expandableConfig, if provided, makes each row in the table "expandable",
+  // i.e. each row has an expand/collapse arrow on its left, and renders
+  // a full-width area below it when expanded.
+  expandableConfig?: {
+    // expandedContent returns the content for a row's full-width expanded
+    // section, given the object that row represents.
+    expandedContent: (obj: T) => React.ReactNode;
+    // expansionKey returns a key used to uniquely identify a row for the
+    // purposes of tracking whether it's expanded or not.
+    expansionKey: (obj: T) => string;
+  };
+  firstCellBordered?: boolean;
+  renderNoResult?: React.ReactNode;
+  pagination?: ISortedTablePagination;
+  loading?: boolean;
+  loadingLabel?: string;
+  // empty state for table
+  empty?: boolean;
+  emptyProps?: EmptyProps;
+}
+
+interface SortedTableState {
+  expandedRows: Set<string>;
+}
+
+/**
+ * SortedTable displays data rows in a table which can be sorted by the values
+ * in a single column. Unsorted row data is passed to SortedTable along with
+ * a SortSetting; SortedTable uses a selector to sort the data for display.
+ *
+ * SortedTable also computes optional "rollup" values for each column; a rollup
+ * is a total value that is computed for a column based on all available rows.
+ *
+ * SortedTable should be preferred over the lower-level SortableTable when
+ * all data rows to be displayed are available locally on the client side.
+ */
+export class SortedTable<T> extends React.Component<
+  SortedTableProps<T>,
+  SortedTableState
+> {
+  static defaultProps: Partial<SortedTableProps<any>> = {
+    rowClass: (_obj: any) => "",
+  };
+
+  rollups = createSelector(
+    (props: SortedTableProps<T>) => props.data,
+    (props: SortedTableProps<T>) => props.columns,
+    (data: T[], columns: ColumnDescriptor<T>[]) => {
+      return _.map(
+        columns,
+        (c): React.ReactNode => {
+          if (c.rollup) {
+            return c.rollup(data);
+          }
+          return undefined;
+        },
+      );
+    },
+  );
+
+  sortedAndPaginated = createSelector(
+    (props: SortedTableProps<T>) => props.data,
+    (props: SortedTableProps<T>) => props.sortSetting,
+    (props: SortedTableProps<T>) => props.columns,
+    (
+      data: T[],
+      sortSetting: SortSetting,
+      columns: ColumnDescriptor<T>[],
+    ): T[] => {
+      if (!sortSetting) {
+        return this.paginatedData();
+      }
+      const sortColumn = columns[sortSetting.sortKey];
+      if (!sortColumn || !sortColumn.sort) {
+        return this.paginatedData();
+      }
+      return this.paginatedData(
+        _.orderBy(
+          data,
+          sortColumn.sort,
+          sortSetting.ascending ? "asc" : "desc",
+        ),
+      );
+    },
+  );
+
+  /**
+   * columns is a selector which computes the input columns to the underlying
+   * sortableTable.
+   */
+  columns = createSelector(
+    this.sortedAndPaginated,
+    this.rollups,
+    (props: SortedTableProps<T>) => props.columns,
+    (
+      sorted: T[],
+      rollups: React.ReactNode[],
+      columns: ColumnDescriptor<T>[],
+    ) => {
+      return _.map(
+        columns,
+        (cd, ii): SortableColumn => {
+          return {
+            title: cd.title,
+            cell: index => cd.cell(sorted[index]),
+            sortKey: cd.sort ? ii : undefined,
+            rollup: rollups[ii],
+            className: cd.className,
+            titleAlign: cd.titleAlign,
+          };
+        },
+      );
+    },
+  );
+
+  rowClass = createSelector(
+    this.sortedAndPaginated,
+    (props: SortedTableProps<T>) => props.rowClass,
+    (sorted: T[], rowClass: (obj: T) => string) => {
+      return (index: number) => rowClass(sorted[index]);
+    },
+  );
+
+  // TODO(vilterp): use a LocalSetting instead so the expansion state
+  // will persist if the user navigates to a different page and back.
+  state: SortedTableState = {
+    expandedRows: new Set<string>(),
+  };
+
+  getItemAt(rowIndex: number): T {
+    const sorted = this.sortedAndPaginated(this.props);
+    return sorted[rowIndex];
+  }
+
+  getKeyAt(rowIndex: number): string {
+    return this.props.expandableConfig.expansionKey(this.getItemAt(rowIndex));
+  }
+
+  onChangeExpansion = (rowIndex: number, expanded: boolean) => {
+    const key = this.getKeyAt(rowIndex);
+    const expandedRows = this.state.expandedRows;
+    if (expanded) {
+      expandedRows.add(key);
+    } else {
+      expandedRows.delete(key);
+    }
+    this.setState({
+      expandedRows: expandedRows,
+    });
+  };
+
+  rowIsExpanded = (rowIndex: number): boolean => {
+    const key = this.getKeyAt(rowIndex);
+    return this.state.expandedRows.has(key);
+  };
+
+  expandedContent = (rowIndex: number): React.ReactNode => {
+    const item = this.getItemAt(rowIndex);
+    return this.props.expandableConfig.expandedContent(item);
+  };
+
+  paginatedData = (sortData?: T[]) => {
+    const { pagination, data } = this.props;
+    if (!pagination) {
+      return sortData || data;
+    }
+    const currentDefault = pagination.current - 1;
+    const start = currentDefault * pagination.pageSize;
+    const end = currentDefault * pagination.pageSize + pagination.pageSize;
+    return sortData ? sortData.slice(start, end) : data.slice(start, end);
+  };
+
+  render() {
+    const {
+      data,
+      loading,
+      sortSetting,
+      onChangeSortSetting,
+      firstCellBordered,
+      renderNoResult,
+      loadingLabel,
+      empty,
+      emptyProps,
+    } = this.props;
+    let expandableConfig: ExpandableConfig = null;
+    if (this.props.expandableConfig) {
+      expandableConfig = {
+        expandedContent: this.expandedContent,
+        rowIsExpanded: this.rowIsExpanded,
+        onChangeExpansion: this.onChangeExpansion,
+      };
+    }
+    return (
+      <SortableTable
+        count={data ? this.paginatedData().length : 0}
+        sortSetting={sortSetting}
+        onChangeSortSetting={onChangeSortSetting}
+        columns={this.columns(this.props)}
+        rowClass={this.rowClass(this.props)}
+        className={this.props.className}
+        expandableConfig={expandableConfig}
+        firstCellBordered={firstCellBordered}
+        renderNoResult={renderNoResult}
+        loading={loading}
+        loadingLabel={loadingLabel}
+        empty={empty}
+        emptyProps={emptyProps}
+      />
+    );
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "allowJs": false,
     "emitDeclarationOnly": true,
     "esModuleInterop": true,
@@ -11,7 +12,7 @@
     "outDir": "./dist/types",
     "target": "es6",
     "skipLibCheck": true,
-    "sourceMap": false,
+    "sourceMap": false
   },
   "exclude": [
     "node_modules",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,6 +18,7 @@ module.exports = {
 
   resolve: {
     extensions: [".ts", ".tsx", ".js", ".jsx"],
+    alias: {src: path.resolve(__dirname, "src")},
   },
 
   module: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2950,6 +2950,11 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.150.tgz#649fe44684c3f1fcb6164d943c5a61977e8cf0bd"
   integrity sha512-kMNLM5JBcasgYscD9x/Gvr6lTAv2NVgsKtet/hm93qMyf/D1pt+7jeEZklKJKxMVmXjxbRVQQGfqDSfipYCO6w==
 
+"@types/long@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz#459c65fa1867dafe6a8f322c4c51695663cc55e9"
+  integrity sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==
+
 "@types/node@*", "@types/node@^13.7.0":
   version "13.13.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.2.tgz#160d82623610db590a64e8ca81784e11117e5a54"
@@ -3029,6 +3034,13 @@
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
+
+"@types/reselect@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@types/reselect/-/reselect-2.2.0.tgz#c667206cfdc38190e1d379babe08865b2288575f"
+  integrity sha1-xmcgbP3DgZDh03m6vgiGWyKIV18=
+  dependencies:
+    reselect "*"
 
 "@types/sinon@^9.0.4":
   version "9.0.4"
@@ -9181,6 +9193,11 @@ lolex@^5.0.0:
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+long@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
+  integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
+
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
@@ -11993,6 +12010,11 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
+
+reselect@*, reselect@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
+  integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
 
 resize-observer-polyfill@^1.5.0, resize-observer-polyfill@^1.5.1:
   version "1.5.1"


### PR DESCRIPTION
Moved SortedTable component from Admin UI, and extended configuration
to resolve `src/...` paths as a module to simplify import paths.
Having import paths relied on `src/index` can reduce issues when
internal structure of the project is changed, so we won't rely on
relative paths.