### PR TITLE
actions: push release tag on publish

### DIFF
--- a/.github/workflows/publish-admin-ui-components.yml
+++ b/.github/workflows/publish-admin-ui-components.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Bump version (prerelease)
         run: |
           yarn version --patch
-          git push --all
+          git push --follow-tags
       - name: Publish ui-components
         run: yarn publish --access public
         env:


### PR DESCRIPTION
Tag is automatically created by yarn but wasn't being synced with github
