### PR TITLE
Add onSortTable handler for StatementsPage

### DIFF
--- a/src/sortabletable/sortabletable.spec.tsx
+++ b/src/sortabletable/sortabletable.spec.tsx
@@ -12,16 +12,19 @@ const cx = classNames.bind(styles);
 
 const columns: SortableColumn[] = [
   {
+    name: "first",
     title: "first",
     cell: index => index.toString() + ".first",
     sortKey: 1,
   },
   {
+    name: "second",
     title: "second",
     cell: index => index.toString() + ".second",
     sortKey: 2,
   },
   {
+    name: "unsortable",
     title: "unsortable",
     cell: index => index.toString() + ".unsortable",
   },
@@ -153,6 +156,7 @@ describe("<SortableTable>", () => {
         spy.calledWith({
           sortKey: 1,
           ascending: false,
+          columnTitle: "first",
         }),
       );
     });
@@ -171,6 +175,7 @@ describe("<SortableTable>", () => {
         spy.calledWith({
           sortKey: 1,
           ascending: false,
+          columnTitle: "first",
         }),
       );
     });
@@ -188,6 +193,7 @@ describe("<SortableTable>", () => {
         spy.calledWith({
           sortKey: 1,
           ascending: true,
+          columnTitle: "first",
         }),
       );
     });
@@ -205,6 +211,7 @@ describe("<SortableTable>", () => {
         spy.calledWith({
           sortKey: null,
           ascending: false,
+          columnTitle: "first",
         }),
       );
     });

--- a/src/sortabletable/sortabletable.stories.tsx
+++ b/src/sortabletable/sortabletable.stories.tsx
@@ -7,9 +7,9 @@ storiesOf("Sortable table", module)
   .add("Empty state", () => <SortableTable empty />)
   .add("With data", () => {
     const columns = [
-      { title: "Col 1", cell: (idx: number) => `row-${idx} col-1` },
-      { title: "Col 2", cell: (idx: number) => `row-${idx} col-2` },
-      { title: "Col 3", cell: (idx: number) => `row-${idx} col-3` },
+      { name: "Col 1", title: "Col 1", cell: (idx: number) => `row-${idx} col-1` },
+      { name: "Col 2", title: "Col 2", cell: (idx: number) => `row-${idx} col-2` },
+      { name: "Col 3", title: "Col 3", cell: (idx: number) => `row-${idx} col-3` },
     ];
     return <SortableTable columns={columns} count={3} />;
   });

--- a/src/sortabletable/sortabletable.tsx
+++ b/src/sortabletable/sortabletable.tsx
@@ -30,6 +30,8 @@ export interface SortableColumn {
   // className is a classname to apply to the td elements
   className?: string;
   titleAlign?: "left" | "right" | "center";
+  // uniq column identifier
+  name: string;
 }
 
 /**
@@ -41,6 +43,7 @@ export interface SortableColumn {
 export interface SortSetting {
   sortKey: any;
   ascending: boolean;
+  columnTitle?: string;
 }
 
 /**
@@ -110,7 +113,7 @@ export class SortableTable extends React.Component<TableProps> {
     activeIndex: NaN,
   };
 
-  clickSort(clickedSortKey: any) {
+  clickSort(clickedSortKey: any, columnTitle?: string) {
     const { sortSetting, onChangeSortSetting } = this.props;
 
     // If the sort key is different than the previous key, initial sort
@@ -128,6 +131,7 @@ export class SortableTable extends React.Component<TableProps> {
     onChangeSortSetting({
       sortKey: clickedSortKey,
       ascending,
+      columnTitle,
     });
   }
 
@@ -244,7 +248,7 @@ export class SortableTable extends React.Component<TableProps> {
                 if (!isUndefined(c.sortKey)) {
                   classes.push(cx("sort-table__cell--sortable"));
                   onClick = () => {
-                    this.clickSort(c.sortKey);
+                    this.clickSort(c.sortKey, c.name);
                   };
                   if (c.sortKey === sortSetting.sortKey) {
                     if (sortSetting.ascending) {

--- a/src/sortedtable/sortedtable.spec.tsx
+++ b/src/sortedtable/sortedtable.spec.tsx
@@ -20,11 +20,13 @@ class TestRow {
 
 const columns: ColumnDescriptor<TestRow>[] = [
   {
+    name: "first",
     title: "first",
     cell: tr => tr.name,
     sort: tr => tr.name,
   },
   {
+    name: "second",
     title: "second",
     cell: tr => tr.value.toString(),
     sort: tr => tr.value,
@@ -93,6 +95,7 @@ describe("<SortedTable>", function() {
     assert.deepEqual(spy.getCall(0).args[0], {
       sortKey: 0,
       ascending: false,
+      columnTitle: "first",
     } as SortSetting);
   });
 

--- a/src/sortedtable/sortedtable.tsx
+++ b/src/sortedtable/sortedtable.tsx
@@ -38,6 +38,8 @@ export interface ColumnDescriptor<T> {
   // className to be applied to the td elements in this column.
   className?: string;
   titleAlign?: "left" | "right" | "center";
+  // uniq column identifier
+  name: string;
 }
 
 /**
@@ -164,6 +166,7 @@ export class SortedTable<T> extends React.Component<
         columns,
         (cd, ii): SortableColumn => {
           return {
+            name: cd.name,
             title: cd.title,
             cell: index => cd.cell(sorted[index]),
             sortKey: cd.sort ? ii : undefined,

--- a/src/statementsPage/statementsPage.fixture.ts
+++ b/src/statementsPage/statementsPage.fixture.ts
@@ -383,7 +383,6 @@ const statementsPagePropsFixture: StatementsPageProps = {
   refreshStatementDiagnosticsRequests: () => {},
   refreshStatements: () => {},
   onActivateStatementDiagnostics: _statement => {},
-  refreshDiagnosticsReports: () => {},
   onDiagnosticsModalOpen: () => {},
 };
 

--- a/src/statementsPage/statementsPage.tsx
+++ b/src/statementsPage/statementsPage.tsx
@@ -47,7 +47,11 @@ interface OwnProps {
   onDiagnosticsModalOpen: (statement: string) => void;
   onSearchComplete?: (results: AggregateStatistics[]) => void;
   onPageChanged?: (newPage: number) => void;
-  onSortingChange?: (name: string, columnTitle: string, ascending: boolean) => void;
+  onSortingChange?: (
+    name: string,
+    columnTitle: string,
+    ascending: boolean,
+  ) => void;
 }
 
 export interface StatementsPageState {
@@ -124,7 +128,11 @@ export class StatementsPage extends React.Component<
       sortKey: ss.sortKey,
       ascending: Boolean(ss.ascending).toString(),
     });
-    this.props.onSortingChange("statements-table", ss.sortKey, ss.ascending);
+    this.props.onSortingChange(
+      "statements-table",
+      ss.columnTitle,
+      ss.ascending,
+    );
   };
 
   selectApp = (app: DropdownOption) => {

--- a/src/statementsPage/statementsPage.tsx
+++ b/src/statementsPage/statementsPage.tsx
@@ -45,9 +45,9 @@ interface OwnProps {
   dismissAlertMessage: () => void;
   onActivateStatementDiagnostics: (statement: string) => void;
   onDiagnosticsModalOpen: (statement: string) => void;
-  refreshDiagnosticsReports: () => void;
   onSearchComplete?: (results: AggregateStatistics[]) => void;
   onPageChanged?: (newPage: number) => void;
+  onSortingChange?: (name: string, columnTitle: string, ascending: boolean) => void;
 }
 
 export interface StatementsPageState {
@@ -124,6 +124,7 @@ export class StatementsPage extends React.Component<
       sortKey: ss.sortKey,
       ascending: Boolean(ss.ascending).toString(),
     });
+    this.props.onSortingChange("statements-table", ss.sortKey, ss.ascending);
   };
 
   selectApp = (app: DropdownOption) => {
@@ -332,7 +333,7 @@ export class StatementsPage extends React.Component<
   render() {
     const {
       match,
-      refreshDiagnosticsReports,
+      refreshStatementDiagnosticsRequests,
       onActivateStatementDiagnostics,
       onDiagnosticsModalOpen,
     } = this.props;
@@ -353,7 +354,7 @@ export class StatementsPage extends React.Component<
         <ActivateStatementDiagnosticsModal
           ref={this.activateDiagnosticsRef}
           activate={onActivateStatementDiagnostics}
-          refreshDiagnosticsReports={refreshDiagnosticsReports}
+          refreshDiagnosticsReports={refreshStatementDiagnosticsRequests}
           onOpenModal={onDiagnosticsModalOpen}
         />
       </React.Fragment>

--- a/src/statementsTable/statementsTable.tsx
+++ b/src/statementsTable/statementsTable.tsx
@@ -52,6 +52,7 @@ function makeCommonColumns(
 
   return [
     {
+      name: "retries",
       title: StatementTableTitle.retries,
       className: cx("statements-table__col-retries"),
       cell: retryBar,
@@ -59,18 +60,21 @@ function makeCommonColumns(
         longToInt(stmt.stats.count) - longToInt(stmt.stats.first_attempt_count),
     },
     {
+      name: "executionCount",
       title: StatementTableTitle.executionCount,
       className: cx("statements-table__col-count"),
       cell: countBar,
       sort: stmt => FixLong(stmt.stats.count).toInt(),
     },
     {
+      name: "rowsAffected",
       title: StatementTableTitle.rowsAffected,
       className: cx("statements-table__col-rows"),
       cell: rowsBar,
       sort: stmt => stmt.stats.num_rows.mean,
     },
     {
+      name: "latency",
       title: StatementTableTitle.latency,
       className: cx("statements-table__col-latency"),
       cell: latencyBar,
@@ -118,12 +122,14 @@ export function makeStatementsColumns(
 ): ColumnDescriptor<AggregateStatistics>[] {
   const columns: ColumnDescriptor<AggregateStatistics>[] = [
     {
+      name: "statements",
       title: StatementTableTitle.statements,
       className: cx("cl-table__col-query-text"),
       cell: StatementTableCell.statements(search, selectedApp),
       sort: stmt => stmt.label,
     },
     {
+      name: "txtType",
       title: StatementTableTitle.txtType,
       className: cx("statements-table__col-time"),
       cell: stmt => (stmt.implicitTxn ? "Implicit" : "Explicit"),
@@ -134,6 +140,7 @@ export function makeStatementsColumns(
 
   if (activateDiagnosticsRef) {
     const diagnosticsColumn: ColumnDescriptor<AggregateStatistics> = {
+      name: "diagnostics",
       title: StatementTableTitle.diagnostics,
       cell: StatementTableCell.diagnostics(activateDiagnosticsRef),
       sort: stmt => {
@@ -156,9 +163,9 @@ export function makeNodesColumns(
 ): ColumnDescriptor<AggregateStatistics>[] {
   const original: ColumnDescriptor<AggregateStatistics>[] = [
     {
+      name: "nodes",
       title: null,
       cell: StatementTableCell.nodeLink(nodeNames),
-      // sort: (stmt) => stmt.label,
     },
   ];
 


### PR DESCRIPTION
Related to https://github.com/cockroachdb/cockroach/pull/51910#discussion_r463029444

When StatementsPage component was extracted, analytics tracking
functionality which was embedded into component has been removed and
should be handled outside of component (with respective callback
functions).
`trackTableSort` tracking function was missing. To make it work,
`onSortingChange` prop is added to handle it outside.

ColumnDescriptor configuration provides information about existing
columns in the table. The issue appeared when a user sorts data by some
column and it is necessary to know column name (to send it as part
of analytics data). Previously, `title` column was used for this
purpose, but the problem is that `title` field is ReactNode, not string.
It means, after casting field to string - it always has [object Object]
value instead of a meaningful column name.

With the current change, ColumnDescriptor configuration is extended with
extra string field "name" as unique column name.