### PR TITLE
Set d3 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "@cockroachlabs/icons": "^0.2.2",
     "@popperjs/core": "^2.4.0",
-    "d3": "<4.0.0",
     "long": "^4.0.0",
     "react-helmet": "^5.2.0",
     "react-popper": "^2.2.3",
@@ -69,6 +68,7 @@
     "babel-preset-react-app": "^9.1.2",
     "chai": "^4.2.0",
     "classnames": "^2.2.6",
+    "d3": "3.5.17",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",
     "eslint": "^6.8.0",
@@ -102,6 +102,7 @@
     "webpackbar": "^4.0.0"
   },
   "peerDependencies": {
+    "d3": "3.5.17",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-router-dom": "^5.1.2"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -110,6 +110,7 @@ module.exports = {
   // This is important because it allows us to avoid bundling all of our
   // dependencies, which allows browsers to cache those libraries between builds.
   externals: {
+    d3: "d3",
     react: {
       commonjs: "react",
       commonjs2: "react",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5592,7 +5592,7 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-d3@<4.0.0:
+d3@3.5.17:
   version "3.5.17"
   resolved "https://registry.yarnpkg.com/d3/-/d3-3.5.17.tgz#bc46748004378b21a360c9fc7cf5231790762fb8"
   integrity sha1-vEZ0gAQ3iyGjYMn8fPUjF5B2L7g=


### PR DESCRIPTION
Including D3 into bundle caused an issue when two instances of d3
is defined in DOM. To avoid this, d3 is defined as peerDependency
and isn't included in bundle.