### PR TITLE
transactions page: broken page on missing statement ids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
 dist
-.DS_STORE

--- a/src/transactionsPage/transactions.fixture.ts
+++ b/src/transactionsPage/transactions.fixture.ts
@@ -853,7 +853,7 @@ export const data = {
     },
     {
       stats_data: {
-        statement_ids: ["www"],
+        statement_ids: ["www", "wwz"],
         app: "$ TEST",
         stats: {
           count: "140",

--- a/src/transactionsPage/utils.ts
+++ b/src/transactionsPage/utils.ts
@@ -48,19 +48,25 @@ export const getStatementsById = (
   statementsIds: string[],
   statements: StatementStatistics[],
 ) => {
-  return statementsIds.map((id: string) => {
-    const statement = statements.find(
-      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-      // @ts-ignore
-      (statement: StatementStatistics) => statement.id === id,
-    );
-    return {
-      ...statement,
-      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-      // @ts-ignore
-      label: statement.key.key_data.query,
-    };
-  });
+  return statementsIds
+    .map((id: string) => {
+      return statements.find(
+        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+        // @ts-ignore
+        (statement: StatementStatistics) => statement.id === id,
+      );
+    })
+    .filter(statement => {
+      return statement != null;
+    })
+    .map(statement => {
+      return {
+        ...statement,
+        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+        // @ts-ignore
+        label: statement.key.key_data.query,
+      };
+    });
 };
 
 export const searchTransactionsData = (


### PR DESCRIPTION
It appears that it's possible to have a payload from the server with
statementIds referenced by transactions that are not in the list of statements.

Our code now gracefully deals with this by just omitting those statements when
looking up the invidual statements by their IDs.

Added a case to one of the fixtures for this to ensure that storybook loads
correctly in this instance.

Refactored the map and code in `getStatementsById` to more clearly break up its
steps so we can filter out nulls in the middle.