### PR TITLE
NotificationWidget Component

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,9 @@
   "license": "MIT",
   "dependencies": {
     "@cockroachlabs/crdb-protobuf-client": "^0.0.1",
+    "@cockroachlabs/design-tokens": "^0.0.7",
     "@cockroachlabs/icons": "^0.2.2",
-    "@cockroachlabs/ui-components": "^0.2.8",
+    "@cockroachlabs/ui-components": "^0.2.10",
     "@popperjs/core": "^2.4.0",
     "babel-polyfill": "^6.26.0",
     "highlight.js": "^10.2.0",

--- a/src/NotificationMessage/NotificationMessage.stories.tsx
+++ b/src/NotificationMessage/NotificationMessage.stories.tsx
@@ -26,7 +26,7 @@ const NotificationFrame: FunctionComponent<ReactProps> = ({ children }) => (
   <section
     style={{
       width: "30rem",
-      padding: "2rem",
+      padding: "2rem 1rem",
       border: "1px dotted #222",
       margin: "0 2rem 2rem 0",
     }}

--- a/src/NotificationMessage/NotificationMessage.stories.tsx
+++ b/src/NotificationMessage/NotificationMessage.stories.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent, ReactNode } from "react";
 
-import { NotificationProps, generateNotificationProps } from "../Notifications";
+import { generateNotificationProps, testNotifications } from "../Notifications";
 import { NotificationMessage } from "./index";
 
 type ReactProps = {
@@ -11,45 +11,6 @@ export default {
   title: "Notfication Message",
   component: NotificationMessage,
 };
-
-const testNotifications: Array<NotificationProps> = [
-  {
-    id: 1,
-    type: "backup-blocked",
-    timestamp: "30 JUL 2020 13:22",
-    read: true,
-  },
-  {
-    id: 2,
-    type: "command-commit",
-    timestamp: "30 JUL 2020 13:25",
-    read: false,
-  },
-  {
-    id: 3,
-    type: "expired",
-    timestamp: "30 JUL 2020 13:30",
-    read: false,
-  },
-  {
-    id: 4,
-    type: "full-table",
-    timestamp: "30 JUL 2020 13:35",
-    read: true,
-  },
-  {
-    id: 5,
-    type: "expired",
-    timestamp: "30 JUL 2020 14:35",
-    read: true,
-  },
-  {
-    id: 6,
-    type: "network-partition",
-    timestamp: "12 AUG 2020 10:00",
-    read: false,
-  },
-];
 
 const notificationMessages = generateNotificationProps(testNotifications);
 

--- a/src/NotificationMessage/NotificationMessage.stories.tsx
+++ b/src/NotificationMessage/NotificationMessage.stories.tsx
@@ -40,7 +40,7 @@ export const Demo = () => (
     <h1>Notification Types</h1>
     <NotificationsMessageTypes>
       {notificationMessages.map(n => (
-        <section key={n.id}>
+        <section key={n.notificationId}>
           <code>{n.type}</code>
           <NotificationFrame>
             <NotificationMessage {...n} />

--- a/src/NotificationMessage/NotificationMessage.tsx
+++ b/src/NotificationMessage/NotificationMessage.tsx
@@ -2,17 +2,21 @@ import React, { FunctionComponent, HTMLAttributes } from "react";
 import classnames from "classnames/bind";
 import { Badge, BadgeIntent, FuzzyTime } from "@cockroachlabs/ui-components";
 
-import {
-  NotificationTypeProp,
-  NotificationProps,
-  NotificationSeverity,
-} from "../Notifications";
+import { NotificationType, NotificationSeverity } from "../Notifications";
 
 import styles from "./notificationMessage.module.scss";
 
-export type NotificationMessageProps = NotificationTypeProp &
-  NotificationProps &
-  HTMLAttributes<HTMLElement>;
+export type OwnProps = {
+  description: string;
+  notificationId: number;
+  read: boolean;
+  severity: NotificationSeverity;
+  timestamp: string;
+  title: string;
+  type: NotificationType;
+};
+
+export type NotificationMessageProps = OwnProps & HTMLAttributes<HTMLElement>;
 
 const cx = classnames.bind(styles);
 
@@ -35,7 +39,6 @@ const severityIntent = (s: NotificationSeverity): BadgeIntent => {
 export const NotificationMessage: FunctionComponent<NotificationMessageProps> = ({
   className,
   description,
-  id,
   read,
   severity,
   timestamp,
@@ -45,7 +48,6 @@ export const NotificationMessage: FunctionComponent<NotificationMessageProps> = 
   const time = new Date(timestamp);
   return (
     <section
-      key={id}
       className={cx("notification-message", { unread: !read }, className)}
       {...rest}
     >

--- a/src/NotificationMessage/NotificationMessage.tsx
+++ b/src/NotificationMessage/NotificationMessage.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from "react";
+import React, { FunctionComponent, HTMLAttributes } from "react";
 import classnames from "classnames/bind";
 import { Badge, BadgeIntent, FuzzyTime } from "@cockroachlabs/ui-components";
 
@@ -10,7 +10,9 @@ import {
 
 import styles from "./notificationMessage.module.scss";
 
-export type NotificationMessageProps = NotificationTypeProp & NotificationProps;
+export type NotificationMessageProps = NotificationTypeProp &
+  NotificationProps &
+  HTMLAttributes<HTMLElement>;
 
 const cx = classnames.bind(styles);
 
@@ -31,16 +33,22 @@ const severityIntent = (s: NotificationSeverity): BadgeIntent => {
 };
 
 export const NotificationMessage: FunctionComponent<NotificationMessageProps> = ({
-  id,
+  className,
   description,
+  id,
   read,
   severity,
   timestamp,
   title,
+  ...rest
 }) => {
   const time = new Date(timestamp);
   return (
-    <section key={id} className={cx("notification-message", { unread: !read })}>
+    <section
+      key={id}
+      className={cx("notification-message", { unread: !read }, className)}
+      {...rest}
+    >
       <header className={cx("title")}>{title}</header>
       <Badge className={cx("severity")} intent={severityIntent(severity)}>
         {severity}

--- a/src/NotificationMessage/NotificationMessage.tsx
+++ b/src/NotificationMessage/NotificationMessage.tsx
@@ -49,16 +49,18 @@ export const NotificationMessage: FunctionComponent<NotificationMessageProps> = 
     <section
       className={cx("notification-message", { unread: !read }, className)}
     >
-      <header className={cx("title")}>{title}</header>
-      <Badge className={cx("severity")} intent={severityIntent(severity)}>
-        {severity}
-      </Badge>
-      {description && (
-        <div className={cx("description")}>{truncate(description, 120)}</div>
-      )}
-      <div className={cx("timestamp")}>
-        <FuzzyTime timestamp={time} />
-      </div>
+      <section className={cx("message-frame")}>
+        <header className={cx("title")}>{title}</header>
+        <Badge className={cx("severity")} intent={severityIntent(severity)}>
+          {severity}
+        </Badge>
+        {description && (
+          <div className={cx("description")}>{truncate(description, 120)}</div>
+        )}
+        <footer className={cx("timestamp")}>
+          <FuzzyTime timestamp={time} />
+        </footer>
+      </section>
     </section>
   );
 };

--- a/src/NotificationMessage/NotificationMessage.tsx
+++ b/src/NotificationMessage/NotificationMessage.tsx
@@ -43,13 +43,11 @@ export const NotificationMessage: FunctionComponent<NotificationMessageProps> = 
   severity,
   timestamp,
   title,
-  ...rest
 }) => {
   const time = new Date(timestamp);
   return (
     <section
       className={cx("notification-message", { unread: !read }, className)}
-      {...rest}
     >
       <header className={cx("title")}>{title}</header>
       <Badge className={cx("severity")} intent={severityIntent(severity)}>

--- a/src/NotificationMessage/notificationMessage.module.scss
+++ b/src/NotificationMessage/notificationMessage.module.scss
@@ -1,10 +1,18 @@
+@import "~@cockroachlabs/design-tokens/dist/web/tokens";
 @import "../core/index.module.scss";
 
 .notification-message {
-  box-shadow: 0px 1px 0px #dbe1ea;
-  font-family: "SourceSansPro-Regular, sans-serif";
-  margin-left: 1.875rem;
+  font-family: "SourceSansPro-Regular", sans-serif;
+  padding-left: 28px;
   position: relative;
+}
+
+.message-frame {
+  border-bottom: 1px solid $color-core-neutral-3;
+  padding: 8px 13px 0;
+  .notification-message:hover & {
+    background-color: $color-core-neutral-1;
+  }
 }
 
 .unread {
@@ -15,32 +23,35 @@
   content: "";
   border-radius: 5px;
   position: absolute;
-  left: -1.75rem;
-  top: 0.4375rem;
-  height: 0.625rem;
-  width: 0.625rem;
-  background-color: #0788ff;
+  left: 0;
+  top: 16px;
+  height: 10px;
+  width: 10px;
+  background-color: $color-core-blue-3;
 }
 
 .title {
-  font-size: 0.875rem;
+  font-size: 14px;
   font-weight: bold;
-  line-height: 1.5rem;
-  margin: 1rem 0;
+  line-height: 24px;
+
+  .notification-message:hover & {
+    color: $color-core-blue-3;
+  }
 }
 
 .description {
-  font-size: 0.875rem;
-  line-height: 1.2rem;
-  margin: 1rem 0;
+  font-size: 14px;
+  line-height: 22px;
+  margin: 0;
 }
 
 .timestamp {
-  margin: 1rem 0 0.5rem;
+  margin: 16px 0 8px;
 }
 
 .severity {
   position: absolute;
-  top: 2px;
+  top: 8px;
   right: 10px;
 }

--- a/src/NotificationWidget/NotificationWidget.stories.tsx
+++ b/src/NotificationWidget/NotificationWidget.stories.tsx
@@ -1,0 +1,46 @@
+import React, { FunctionComponent } from "react";
+
+import { Link, LinkProps } from "../index";
+
+import {
+  testNotifications,
+  generateNotificationProps,
+  getUnread,
+} from "../Notifications";
+import { NotificationWidget } from "./NotificationWidget";
+
+export default {
+  title: "Notification Widget",
+  component: NotificationWidget,
+};
+
+const notificationMessages = generateNotificationProps(testNotifications);
+
+const NotificationCenterLink: FunctionComponent<LinkProps> = props => {
+  return (
+    <Link onClick={() => console.log("go to notif center")} {...props}>
+      Notification Center
+    </Link>
+  );
+};
+
+const NotificationsWidgetContainer: FunctionComponent = ({ children }) => (
+  <section style={{ width: "33rem", border: "1px dotted #222" }}>
+    {children}
+  </section>
+);
+
+export const Example = () => (
+  <section style={{ padding: "2rem" }}>
+    <h1>Notification Widget</h1>
+    <NotificationsWidgetContainer>
+      <NotificationWidget
+        messages={notificationMessages}
+        unread={getUnread(notificationMessages)}
+        markAllNotificationsRead={() => console.log("mark all as read")}
+        markNotificationRead={(id: number) => console.log(`id - ${id}`)}
+        NotificationCenterLink={NotificationCenterLink}
+      />
+    </NotificationsWidgetContainer>
+  </section>
+);

--- a/src/NotificationWidget/NotificationWidget.tsx
+++ b/src/NotificationWidget/NotificationWidget.tsx
@@ -1,0 +1,78 @@
+import React, { FunctionComponent } from "react";
+import classnames from "classnames/bind";
+
+import { Link } from "../index";
+
+import {
+  NotificationMessage,
+  NotificationMessageProps,
+} from "../NotificationMessage";
+
+import styles from "./notificationWidget.module.scss";
+
+// const pick = (obj, keys) => {
+//   return keys.reduce((acc, cur) => {
+//     acc[cur] = obj[cur];
+//     return acc;
+//   }, {});
+// }
+
+const cx = classnames.bind(styles);
+
+export type NotificationWidgetProps = {
+  messages: Array<NotificationMessageProps>;
+  unread: number;
+  markNotificationRead: (id: number) => void;
+  markAllNotificationsRead: () => void;
+  NotificationCenterLink: React.FunctionComponent<{ className: string }>;
+  debug?: boolean;
+};
+
+export const NotificationWidget: FunctionComponent<NotificationWidgetProps> = ({
+  messages,
+  markAllNotificationsRead,
+  markNotificationRead,
+  NotificationCenterLink,
+  unread,
+  debug = false,
+}) => (
+  <section className={cx("notifications-widget")}>
+    <header>
+      <strong>Notifications</strong> - <strong>{unread}</strong> unread
+    </header>
+
+    <div className={cx("messages")}>
+      {messages.map(m => (
+        <NotificationMessage
+          key={m.notificationId}
+          onClick={() => markNotificationRead(m.notificationId)}
+          {...m}
+        />
+      ))}
+    </div>
+    <footer className={cx("indent")}>
+      <Link
+        className={cx("widget-footer-link")}
+        onClick={markAllNotificationsRead}
+      >
+        Mark All as Read
+      </Link>
+      | <NotificationCenterLink className={cx("widget-footer-link")} />
+    </footer>
+
+    {debug && (
+      <div
+        style={{
+          backgroundColor: "#eee",
+          border: "1px dotted #222",
+          margin: "2rem 0 0 0",
+          padding: "0 0 0 1rem",
+        }}
+      >
+        <code>
+          <pre>{JSON.stringify(messages, null, 2)}</pre>
+        </code>
+      </div>
+    )}
+  </section>
+);

--- a/src/NotificationWidget/NotificationWidget.tsx
+++ b/src/NotificationWidget/NotificationWidget.tsx
@@ -50,14 +50,11 @@ export const NotificationWidget: FunctionComponent<NotificationWidgetProps> = ({
         />
       ))}
     </div>
-    <footer className={cx("indent")}>
-      <Link
-        className={cx("widget-footer-link")}
-        onClick={markAllNotificationsRead}
-      >
+    <footer className={cx("footer", "indent")}>
+      <Link className={cx("footer-link")} onClick={markAllNotificationsRead}>
         Mark All as Read
       </Link>
-      | <NotificationCenterLink className={cx("widget-footer-link")} />
+      | <NotificationCenterLink className={cx("footer-link")} />
     </footer>
 
     {debug && (

--- a/src/NotificationWidget/index.ts
+++ b/src/NotificationWidget/index.ts
@@ -1,0 +1,1 @@
+export * from "./NotificationWidget";

--- a/src/NotificationWidget/notificationWidget.module.scss
+++ b/src/NotificationWidget/notificationWidget.module.scss
@@ -3,15 +3,26 @@
 }
 
 .notifications-widget {
-  //       22px     40px   28px    26px
-  padding: 1.375rem 2.5rem 1.75rem 1.625rem;
+  padding: 22px 40px 28px 26px;
 }
 
 .messages {
   margin: 1rem 0 0 0;
 }
 
-.widget-footer-link {
+.footer {
   font-weight: 400;
-  padding: 0 1rem;
+  margin-top: 30px;
+}
+
+.footer-link {
+  margin: 0 16px;
+
+  &:first-child {
+    margin-left: 0;
+  }
+
+  &:last-child {
+    margin-right: 0;
+  }
 }

--- a/src/NotificationWidget/notificationWidget.module.scss
+++ b/src/NotificationWidget/notificationWidget.module.scss
@@ -1,0 +1,17 @@
+.indent {
+  margin-left: 1.875rem;
+}
+
+.notifications-widget {
+  //       22px     40px   28px    26px
+  padding: 1.375rem 2.5rem 1.75rem 1.625rem;
+}
+
+.messages {
+  margin: 1rem 0 0 0;
+}
+
+.widget-footer-link {
+  font-weight: 400;
+  padding: 0 1rem;
+}

--- a/src/Notifications/index.ts
+++ b/src/Notifications/index.ts
@@ -1,2 +1,3 @@
 export * from "./notificationTypes";
 export * from "./notifications";
+export * from "./notificationUtils";

--- a/src/Notifications/notificationTypes.ts
+++ b/src/Notifications/notificationTypes.ts
@@ -6,13 +6,13 @@ export type NotificationType =
   | "network-partition";
 export type NotificationSeverity = "low" | "info" | "moderate" | "critical";
 export type NotificationTypeProp = {
-  key: string;
+  notificationKey: string;
   title: string;
   description: string;
   severity: NotificationSeverity;
 };
 export type NotificationProps = {
-  id: number;
+  notificationId: number;
   read: boolean;
   timestamp: string;
   type: NotificationType;
@@ -20,35 +20,35 @@ export type NotificationProps = {
 
 export const notificationTypes: Array<NotificationTypeProp> = [
   {
-    key: "backup-blocked",
+    notificationKey: "backup-blocked",
     title: "Backup blocked on long-running Transaction",
     description:
       "There is a long running transaction that has prevented a backup on a table for more than 1 hour.",
     severity: "low",
   },
   {
-    key: "command-commit",
+    notificationKey: "command-commit",
     title: "Command Commit Latency",
     description:
       "Command Commit Latency is > 100ms on at least one node in this cluster. This can result in poor query performance.",
     severity: "low",
   },
   {
-    key: "expired",
+    notificationKey: "expired",
     title: "Expired License Key",
     description:
       "Your enterprise license key has expired. Enterprise features are disabled until a new license key is set.",
     severity: "moderate",
   },
   {
-    key: "full-table",
+    notificationKey: "full-table",
     title: "Full Table Scan",
     description:
       "There are queries resulting in full table scans in this cluster. Full table scans may result in poor query performance.",
     severity: "low",
   },
   {
-    key: "network-partition",
+    notificationKey: "network-partition",
     title: "Network Partition",
     description: "There may be a network partition in this cluster.",
     severity: "critical",

--- a/src/Notifications/notificationUtils.ts
+++ b/src/Notifications/notificationUtils.ts
@@ -2,37 +2,37 @@ import { NotificationProps } from ".";
 
 export const testNotifications: Array<NotificationProps> = [
   {
-    id: 1,
+    notificationId: 1,
     type: "backup-blocked",
     timestamp: "30 JUL 2020 13:22",
     read: true,
   },
   {
-    id: 2,
+    notificationId: 2,
     type: "command-commit",
     timestamp: "30 JUL 2020 13:25",
     read: false,
   },
   {
-    id: 3,
+    notificationId: 3,
     type: "expired",
     timestamp: "30 JUL 2020 13:30",
     read: false,
   },
   {
-    id: 4,
+    notificationId: 4,
     type: "full-table",
     timestamp: "30 JUL 2020 13:35",
     read: true,
   },
   {
-    id: 5,
+    notificationId: 5,
     type: "expired",
     timestamp: "30 JUL 2020 14:35",
     read: true,
   },
   {
-    id: 6,
+    notificationId: 6,
     type: "network-partition",
     timestamp: "12 AUG 2020 10:00",
     read: false,

--- a/src/Notifications/notificationUtils.ts
+++ b/src/Notifications/notificationUtils.ts
@@ -1,0 +1,43 @@
+import { NotificationProps } from ".";
+
+export const testNotifications: Array<NotificationProps> = [
+  {
+    id: 1,
+    type: "backup-blocked",
+    timestamp: "30 JUL 2020 13:22",
+    read: true,
+  },
+  {
+    id: 2,
+    type: "command-commit",
+    timestamp: "30 JUL 2020 13:25",
+    read: false,
+  },
+  {
+    id: 3,
+    type: "expired",
+    timestamp: "30 JUL 2020 13:30",
+    read: false,
+  },
+  {
+    id: 4,
+    type: "full-table",
+    timestamp: "30 JUL 2020 13:35",
+    read: true,
+  },
+  {
+    id: 5,
+    type: "expired",
+    timestamp: "30 JUL 2020 14:35",
+    read: true,
+  },
+  {
+    id: 6,
+    type: "network-partition",
+    timestamp: "12 AUG 2020 10:00",
+    read: false,
+  },
+];
+
+export const getUnread = (notifs: Array<NotificationProps>) =>
+  notifs.reduce((acc, notif) => (notif.read ? acc : (acc += 1)), 0);

--- a/src/Notifications/notifications.ts
+++ b/src/Notifications/notifications.ts
@@ -1,12 +1,14 @@
 // This is a placeholder for real implementation (likely in Redux?) of notifications
 
 import { notificationTypes, NotificationProps } from "../Notifications";
-import { NotificationMessageProps } from "../NotificationMessage";
+import { OwnProps as NotificationMessageProps } from "../NotificationMessage";
 
 export const generateNotificationProps = (
   notifications: Array<NotificationProps>,
 ): Array<NotificationMessageProps> =>
   notifications.map(n => {
-    const type = notificationTypes.find(nt => nt.key === n.type);
-    return { ...n, ...type };
+    const notificationType = notificationTypes.find(
+      nt => nt.notificationKey === n.type,
+    );
+    return { ...n, ...notificationType };
   });

--- a/src/core/colors.module.scss
+++ b/src/core/colors.module.scss
@@ -1,5 +1,5 @@
 $colors--neutral-0: #ffffff;
-$colors--neutral-1: #F5F7FA;
+$colors--neutral-1: #f5f7fa;
 $colors--neutral-2: #e7ecf3;
 $colors--neutral-3: #d6dbe7;
 $colors--neutral-4: #c0c6d9;
@@ -9,8 +9,7 @@ $colors--neutral-7: #394455;
 $colors--neutral-8: #242a35;
 $colors--neutral-9: #060c12;
 $colors--neutral-10: #0c1628;
-$colors--neutral-11: #C4C4C4;
-
+$colors--neutral-11: #c4c4c4;
 
 $colors--primary-blue-1: #e0eefb;
 $colors--primary-blue-2: #74bdfd;
@@ -24,7 +23,6 @@ $colors--primary-green-2: #76de49;
 $colors--primary-green-3: #37a806;
 $colors--primary-green-4: #237300;
 $colors--primary-green-5: #123d00;
-
 
 $colors--functional-purple-1: #cec0f2;
 $colors--functional-purple-2: #8c6be1;

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export * from "./button";
 export * from "./dropdown";
 export * from "./empty";
 export * from "./highlightedText";
+export * from "./link";
 export * from "./loading";
 export * from "./modal";
 export * from "./pageConfig";

--- a/src/link/Link.module.scss
+++ b/src/link/Link.module.scss
@@ -1,0 +1,20 @@
+@import "~@cockroachlabs/design-tokens/dist/web/tokens";
+
+.link {
+  color: $color-core-blue-3;
+  display: inline-block;
+}
+
+.link:hover {
+  border-bottom: 1px solid $color-core-blue-3;
+  cursor: pointer;
+}
+
+.disabled {
+  opacity: 0.4;
+}
+
+.disabled:hover {
+  border: none;
+  cursor: not-allowed;
+}

--- a/src/link/Link.stories.tsx
+++ b/src/link/Link.stories.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { action } from "@storybook/addon-actions";
+
+import Link from "./Link";
+
+export default {
+  title: "Link",
+  component: Link,
+};
+
+export const Example = () => (
+  <section style={{ padding: "2rem" }}>
+    <h1>Link</h1>
+    <Link disabled={true} onClick={action("Link Clicked")}>
+      A Link
+    </Link>
+  </section>
+);

--- a/src/link/Link.tsx
+++ b/src/link/Link.tsx
@@ -1,0 +1,44 @@
+import React, { FunctionComponent } from "react";
+import classnames from "classnames/bind";
+
+import styles from "./Link.module.scss";
+
+type OwnLinkProps = {
+  disabled?: boolean;
+};
+
+type NativeSpanProps = Omit<
+  React.HTMLAttributes<HTMLSpanElement>,
+  keyof OwnLinkProps
+>;
+
+export type LinkProps = OwnLinkProps & NativeSpanProps;
+
+const cx = classnames.bind(styles);
+
+export const Link: FunctionComponent<LinkProps> = ({
+  children,
+  className,
+  disabled = false,
+  onClick,
+  ...rest
+}) => {
+  const handler = disabled ? () => {} : onClick;
+  return (
+    <span
+      className={cx(
+        "link",
+        {
+          disabled,
+        },
+        className,
+      )}
+      onClick={handler}
+      {...rest}
+    >
+      {children}
+    </span>
+  );
+};
+
+export default Link;

--- a/src/link/index.ts
+++ b/src/link/index.ts
@@ -1,0 +1,1 @@
+export * from "./Link";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2019,6 +2019,11 @@
   resolved "https://registry.yarnpkg.com/@cockroachlabs/crdb-protobuf-client/-/crdb-protobuf-client-0.0.1.tgz#7924dd7fe6348627ea72df74939ad2321c7056fc"
   integrity sha512-H6TAjH/fgVURlHZoPJKjMO2zr5HRkRUOJvcJDGYi8O0P0R1KU0UyfgxaCbFaGcBUIC4m3vFTdQzcMVDFJWo3wA==
 
+"@cockroachlabs/design-tokens@^0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@cockroachlabs/design-tokens/-/design-tokens-0.0.7.tgz#bcf7c7cd823c19aca66cf5bf6738353837193935"
+  integrity sha512-2pylDORA/R+FwQGAJC261ZbctVvcb3b7Dpd+hb9shN666Tr9G4O98JdMQcHLBn1oqM1zdJAMmCD0fZuY5+htDg==
+
 "@cockroachlabs/eslint-config@^0.1.3":
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/@cockroachlabs/eslint-config/-/eslint-config-0.1.5.tgz#cada7ecf857639c55cfd77a21a48e9f53cecfcef"
@@ -2027,22 +2032,22 @@
     "@typescript-eslint/parser" "^2.34.0"
     eslint-config-prettier "^6.11.0"
 
-"@cockroachlabs/icons@^0.2.10":
+"@cockroachlabs/icons@^0.2.2":
   version "0.2.10"
   resolved "https://registry.yarnpkg.com/@cockroachlabs/icons/-/icons-0.2.10.tgz#c091c8eb499a3681882840f88e0b42977ba940b7"
   integrity sha512-MFBzwbUyFeXoau3neTffsoKJ3WDCJJj/uvlVjO2utfYHN6AEuokcPDiJNSGEkwo2+70ebi6nLjcIFAdoTltyYA==
 
-"@cockroachlabs/icons@^0.2.2":
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/@cockroachlabs/icons/-/icons-0.2.4.tgz#b800ed8fb7a23bab3b86217eedca9174b3ef18f3"
-  integrity sha512-hu9W37fzw30wM5FPEeGnOONL2AAW5uNOtRSdROrFyY6hlRtKli1piE/mfHmSiTfSoZ3SHravCl88ErH6WLqw8g==
+"@cockroachlabs/icons@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@cockroachlabs/icons/-/icons-0.3.0.tgz#160573074396f266e92fcbe5e520c5ba1d8750f9"
+  integrity sha512-GJxhlXy8Z3/PYFb9C3iM1dvU9wajGoaA/+VCj0an2ipfbkI2fhToq+h0b33vu7JuZ3dS4QMRjfVE4uhlyIUH2Q==
 
-"@cockroachlabs/ui-components@^0.2.8":
-  version "0.2.8"
-  resolved "https://registry.yarnpkg.com/@cockroachlabs/ui-components/-/ui-components-0.2.8.tgz#a98a28dda64d854d85a42655faf0607a6f8504d9"
-  integrity sha512-y4SdIC0CaZGG+1FGtSMx8EG1W40yeNnE5LEqOaI4rVGLyMQBXho4Z03dOwkpi9jQyxnI3UTcwHD7oMpGrtoLTQ==
+"@cockroachlabs/ui-components@^0.2.10":
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/@cockroachlabs/ui-components/-/ui-components-0.2.10.tgz#3c1492ae4397204fba8dcafc6fe09e2a0e1aaa57"
+  integrity sha512-m3csfYolWh6Rn0xuDRf0wqr1vErLgK1RVYywzM6k7Tld5O2XI993NyhCi5GNCBjOfbov7Ikq+UE6uc3S3Di9dQ==
   dependencies:
-    "@cockroachlabs/icons" "^0.2.10"
+    "@cockroachlabs/icons" "^0.3.0"
     "@popperjs/core" "^2.4.3"
     react-popper "^2.2.3"
 


### PR DESCRIPTION
The `NotificationWidget` component is made up of a list of `NotificationMessages` with the added concept of _read_ and _unread_ states as well as a footer section for actions to be performed by the widget. It was my goal to keep this component purely [_presentational_](https://redux.js.org/basics/usage-with-react#presentational-and-container-components) and have the state managed by the implementing application (through something like Redux). 

## Read and Unread messages

The unread state of an message is a part of the data model of a `NotificationMessage` and so the number of unread messages can be derived from that data, and the actions to mark individual messages as _read_ or to mark all messages as read are expected to be passed in as props. This gives ultimate control of state to the implementing application which I feel is better suited to manage it's data.

![Screen Shot 2020-10-01 at 14 06 56](https://user-images.githubusercontent.com/397448/94846589-60bd0700-03ef-11eb-9f55-9fe1b49e7998.png)
