### PR TITLE
extend Diagnostics column for statements page

### DIFF
--- a/src/button/button.module.scss
+++ b/src/button/button.module.scss
@@ -1,18 +1,27 @@
 @import '../core/index.module.scss';
 
+@mixin icon-color($color: $colors--neutral-7) {
+  svg {
+    fill: $color;
+  }
+}
+
 .crl-button {
   border-radius: 3px;
   cursor: pointer;
   width: max-content;
+  @include icon-color();
 }
 
 .crl-button--type-flat {
   border: solid 1px transparent;
   background-color: transparent;
   color: $colors--primary-blue-3;
+  @include icon-color($colors--primary-blue-3);
 
   &:hover {
     color: $colors--primary-blue-4;
+    @include icon-color($colors--primary-blue-4);
   }
 
   &:active {
@@ -26,6 +35,7 @@
 
   &.crl-button--disabled {
     color: $colors--neutral-4;
+    @include icon-color($colors--neutral-4);
     pointer-events: none;
     cursor: default;
   }
@@ -40,6 +50,7 @@
   line-height: 22px;
   letter-spacing: 0.1px;
   color: $colors--neutral-7;
+  @include icon-color($colors--neutral-7);
 
   &:hover {
     text-decoration: underline;
@@ -49,10 +60,12 @@
 .crl-button--type-primary {
   background-color: $colors--primary-green-3;
   color: $colors--white;
+  @include icon-color($colors--white);
   border: solid 1px $colors--primary-green-3;
 
   &:hover {
     color: $colors--white;
+    @include icon-color($colors--white);
   }
 
   &:active {
@@ -68,6 +81,7 @@
     border: solid 1px #c4e6ba;
     background: #c4e6ba;
     color: $colors--white;
+    @include icon-color($colors--white);
     pointer-events: none;
     cursor: default;
   }
@@ -76,10 +90,12 @@
 .crl-button--type-secondary {
   background-color: $colors--white;
   color: $colors--primary-text;
+  @include icon-color($colors--primary-text);
   border: solid 1px $colors--neutral-4;
 
   &:hover, &:active, &:focus {
     color: $colors--primary-text;
+    @include icon-color($colors--primary-text);
     background: $colors--neutral-1;
   }
 
@@ -96,6 +112,7 @@
     border: solid 1px $colors--neutral-4;
     background: $colors--neutral-1;
     color: $colors--neutral-5;
+    @include icon-color($colors--neutral-5);
     pointer-events: none;
     cursor: default;
   }
@@ -109,9 +126,9 @@
 }
 
 .crl-button--size-small {
-  height: $line-height--medium;
-  min-width: $line-height--medium;
-  padding: 0 $spacing-xx-small;
+  height: $line-height--large;
+  min-width: $line-height--large;
+  padding: 0 $spacing-base;
 }
 
 .crl-button__container {
@@ -121,13 +138,22 @@
 }
 
 .crl-button__content {
+  display: flex;
   flex: 1;
+}
+
+
+.crl-button__icon {
+  display: flex;
+  align-items: center;
 }
 
 .crl-button__icon--push-left {
   order: -1;
+  margin-right: $spacing-base;
 }
 
 .crl-button__icon--push-right {
   order: 1;
+  margin-left: $spacing-base;
 }

--- a/src/button/button.stories.tsx
+++ b/src/button/button.stories.tsx
@@ -1,0 +1,73 @@
+/* eslint-disable react/jsx-key */
+import React from "react";
+import { storiesOf } from "@storybook/react";
+
+import { Button, ButtonProps } from "src/button";
+import { CaretDown } from "@cockroachlabs/icons";
+import { Text, TextTypes } from "../text";
+
+const sizes: ButtonProps["size"][] = ["default", "small"];
+const types: ButtonProps["type"][] = [
+  "primary",
+  "secondary",
+  "flat",
+  "unstyled-link",
+];
+const icons: ButtonProps["icon"][] = [<CaretDown />, undefined];
+const iconPositions: ButtonProps["iconPosition"][] = ["right", "left"];
+
+storiesOf("Button", module)
+  .addDecorator(renderChild => (
+    <div style={{ padding: "12px", display: "flex" }}>{renderChild()}</div>
+  ))
+  .add("default", () => <Button>Caption</Button>)
+  .add("examples", () => {
+    const buttons = types.map(buttonType => {
+      const buttonsPerSize = sizes.map(size => {
+        const items = icons
+          .map(buttonIcon => {
+            return iconPositions.map(iconPosition => {
+              return (
+                <Button
+                  type={buttonType}
+                  size={size}
+                  icon={buttonIcon}
+                  iconPosition={iconPosition}
+                >
+                  Sample text
+                </Button>
+              );
+            });
+          })
+          .reduce((ac, el) => [...ac, ...el], []);
+
+        return (
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "row",
+              justifyContent: "space-around",
+              margin: "24px 0",
+            }}
+          >
+            {React.Children.toArray(items)}
+          </div>
+        );
+      });
+
+      return (
+        <div>
+          <Text textType={TextTypes.Heading3}>{buttonType} type</Text>
+          <div style={{ display: "flex", flexDirection: "column" }}>
+            {React.Children.toArray(buttonsPerSize)}
+          </div>
+        </div>
+      );
+    });
+
+    return (
+      <div style={{ display: "flex", flexDirection: "column", width: "100%" }}>
+        {React.Children.toArray(buttons)}
+      </div>
+    );
+  });

--- a/src/button/button.tsx
+++ b/src/button/button.tsx
@@ -18,7 +18,7 @@ export interface ButtonProps {
   textAlign?: "left" | "right" | "center";
   size?: "default" | "small";
   children?: React.ReactNode;
-  icon?: () => React.ReactNode;
+  icon?: React.ReactNode;
   iconPosition?: "left" | "right";
   onClick?: (event: React.MouseEvent<HTMLElement>) => void;
   className?: string;
@@ -33,7 +33,7 @@ export function Button(props: ButtonProps) {
     children,
     type,
     disabled,
-    size,
+    size = "default",
     icon,
     iconPosition,
     onClick,
@@ -58,8 +58,12 @@ export function Button(props: ButtonProps) {
       return null;
     }
     return (
-      <div className={cx(`crl-button__icon--push-${iconPosition}`)}>
-        {icon()}
+      <div
+        className={cx("crl-button__icon", {
+          [`crl-button__icon--push-${iconPosition}`]: !!children,
+        })}
+      >
+        {icon}
       </div>
     );
   };

--- a/src/dropdown/dropdown.module.scss
+++ b/src/dropdown/dropdown.module.scss
@@ -1,287 +1,47 @@
 @import "../core/index.module";
 
-$dropdown-hover-color: darken($colors--background, 2.5%);
-
-:global {
-  .Select.is-focused {
-    &:not(.is-open) {
-      .Select-control {
-        box-shadow: none;
-        border: none;
-      }
-    }
-  }
-
-  .Select.is-focused {
-    &:not(.is-open) {
-      .Select-control {
-        box-shadow: none;
-        border: none;
-      }
-    }
-  }
-
-  .Select-value, .Select-placeholder {
-    line-height: inherit !important;
-    // height: auto !important;
-    position: relative !important;
-    white-space: nowrap !important;
-    max-width: 250px !important;
-    padding: 0 0 0 3px !important;
-  }
-
-  .Select-control {
-    line-height: inherit !important;
-    height: auto;
-    border-width: 0 !important;
-    background-color: transparent !important;
-    // width: auto !important;
-
-    &:hover {
-      box-shadow: none;
-    }
-  }
-
-  .Select-input {
-    line-height: inherit !important;
-    height: auto !important;
-    position: absolute !important;
-    top: 0 !important;
-  }
-
-  .Select-input > input {
-    padding: 0 !important;
-  }
-
-  .Select-menu-outer {
-    width: auto !important;
-    border: none !important;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2) !important;
-    max-height: 200px;
-    font-family: $font-family--base;
-    font-size: 14px;
-    text-transform: none;
-    letter-spacing: 0;
-    border-radius: 4px !important;
-    padding: 0 0;
-  }
-
-  .Select-menu, .Select-menu-outer {
-    max-height: 350px;
-  }
-
-  .Select-value-label {
-    // display: block !important;
-    cursor: pointer;
-  }
-
-  .Select-arrow {
-    border-top-color: $colors--neutral-8 !important;
-  }
-
-  .Select {
-    display: block;
-    width: 100%;
-  }
-
-  .dropdown--side-arrows {
-    .Select {
-      padding: 12px 24px !important;
-    }
-
-    .Select-arrow-zone {
-      display: none;
-    }
-  }
-}
-
-.dropdown {
-  font-family: $font-family--semi-bold;
-  padding: 7.5px 10px 7.5px 19px;
-  vertical-align: middle;
-  border: 1px solid $colors--neutral-4;
-  border-radius: 3px;
-  white-space: nowrap;
-  color: $colors--neutral-6;
-  cursor: pointer;
-  position: relative;
-  background: $colors--neutral-0;
+.crl-dropdown {
   display: flex;
-  align-items: center;
-
-  :global(.Select) {
-    position: initial;
-  }
-
-  :global(.Select-menu-outer) {
-    top: calc(100% + 8px);
-    padding: 8px 0;
-  }
-
-  :global(.Select-option) {
-    font-size: 14px;
-    line-height: 22px;
-    font-family: $font-family--base;
-    color: $colors--neutral-7 !important;
-    padding: 8px 30px 8px 16px;
-    &.is-focused, &.is-selected {
-      color: $colors--primary-blue-3 !important;
-      background-color: transparent;
-    }
-  }
-
-  .dropdown__title, :global(.Select-value-label) {
-    color: $colors--neutral-8 !important;
-    font-family: $font-family--semi-bold;
-    font-size: 14px;
-    line-height: 1.71;
-    letter-spacing: 0.1px;
-  }
-
-  &:hover {
-    :global(.Select-arrow-zone) {
-      path {
-        fill: $colors--neutral-5;
-      }
-    }
-  }
-
-  &.dropdown--type-secondary {
-    &:hover {
-      border-color: $colors--neutral-5;
-    }
-
-    &.dropdown__focused {
-      background-color: $colors--neutral-1;
-      border: 1px solid $colors--neutral-5;
-      box-shadow: 0 0 3px 0 $colors--neutral-5;
-    }
-  }
-
-  &.dropdown--type-primary {
-    &:hover {
-      border-color: $colors--neutral-5;
-    }
-
-    &.dropdown__focused {
-      border: 1px solid $colors--primary-blue-3;
-      box-shadow: 0 0 3px 2px $colors--primary-blue-1;
-    }
-  }
-
-  :global(.Select-arrow-zone) {
-    color: $colors--primary-blue-3;
-    .caret-down {
-      display: flex;
-      justify-content: flex-end;
-      align-items: center;
-    }
-    .active {
-      path {
-        fill: $colors--primary-blue-4;
-      }
-    }
-  }
-
-  &._range {
-    width: 423px;
-    padding: 7px 9px;
-  }
-
-  &__title {
-    vertical-align: middle;
-    display: inline-block;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
-    letter-spacing: 2px;
-    line-height: 17px;
-  }
-
-  &__range-title {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    background: $colors--neutral-3;
-    width: 34px;
-    text-align: center;
-    border-radius: 3px;
-    color: $colors--neutral-7;
-    font-size: 12px;
-    line-height: 24px;
-    letter-spacing: 0.1px;
-    font-family: $font-family--bold;
-  }
-
-  &__select {
-    display: inline-block;
-    vertical-align: middle;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
-    letter-spacing: 2px;
-    line-height: 17px;
-  }
-
-  &__side-arrow {
-    font-family: $font-family--bold;
-    display: none;
-    color: $colors--neutral-8;
-    cursor: pointer;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
-
-    &:first-child {
-      border-right: 1px solid $colors--neutral-4;
-      padding: 12px 24px;
-      border-top-left-radius: 4px;
-      border-bottom-left-radius: 4px;
-    }
-
-    &:last-child {
-      border-left: 1px solid $colors--neutral-4;
-      padding: 12px 24px;
-      border-top-right-radius: 4px;
-      border-bottom-right-radius: 4px;
-    }
-
-    &--disabled {
-      background-color: $colors--neutral-2;
-      cursor: auto;
-
-      polyline {
-        stroke: $colors--neutral-4;
-      }
-    }
-  }
-
-  &--side-arrows {
-    padding: 0;
-
-    &:hover {
-      background-color: transparent;
-    }
-
-    .dropdown__side-arrow {
-      display: inline;
-
-      &:hover {
-        background-color: $dropdown-hover-color;
-      }
-    }
-  }
+  flex-direction: column;
 }
-.dropdown.full-size {
-  :global(.Select-menu-outer), :global(.Select-menu) {
-    max-height: 450px;
+
+.crl-dropdown__overlay {
+  position: relative;
+  flex-grow: 0;
+}
+
+.crl-dropdown__menu {
+  position: absolute;
+  display: none;
+
+  &--align-right {
+    right: 0;
   }
 }
 
-.dropdown-caret {
-  width: 8px;
-  height: 6px;
+.crl-dropdown__menu--open {
+  display: block;
+  z-index: 4;
+}
+
+.crl-dropdown__container {
+  position: static;
+  border-radius: 4px;
+  box-shadow: 0 0 4px 0 rgba(154, 161, 171, 0.33);
+  border: solid 0.5px $colors--neutral-2;
+  background-color: $colors--white;
+  min-width: 150px;
+  padding: $spacing-xx-small 0;
+  cursor: pointer;
+  width: max-content;
+}
+
+.crl-dropdown__item {
+  height: $line-height--large;
+  padding: $spacing-xx-small $spacing-small;
+}
+
+.crl-dropdown__item:hover {
+  color: $colors--white;
+  background-color: $colors--primary-blue-3;
 }

--- a/src/dropdown/dropdown.stories.tsx
+++ b/src/dropdown/dropdown.stories.tsx
@@ -1,26 +1,47 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
+import { noop } from "lodash";
 
-import { DropdownOption, Dropdown } from "./";
+import { Dropdown, DropdownOption } from "./dropdown";
+import { Button } from "src/button";
+import { Download } from "@cockroachlabs/icons";
+
+const items: DropdownOption[] = [
+  { name: "A", value: "a" },
+  { name: "B", value: "b" },
+  { name: "C", value: "c" },
+];
 
 storiesOf("Dropdown", module)
   .addDecorator(renderChild => (
     <div style={{ padding: "12px", display: "flex" }}>{renderChild()}</div>
   ))
-  .add("Simple", () => {
-    const options: DropdownOption[] = [
-      { label: "Option 1", value: "option1" },
-      { label: "Option 2", value: "option2" },
-      { label: "Option 3", value: "option3" },
-      { label: "Option 4", value: "option4" },
-    ];
-    const [selected, setSelected] = React.useState(options[1].value);
-    return (
-      <Dropdown
-        options={options}
-        selected={selected}
-        onChange={s => setSelected(s.value)}
-        title="Simple dropdown component"
-      />
-    );
-  });
+  .add("default", () => (
+    <Dropdown onChange={noop} items={items}>
+      Select
+    </Dropdown>
+  ))
+  .add("with custom toggle icon", () => (
+    <Dropdown
+      onChange={noop}
+      items={items}
+      customToggleButton={
+        <Button type="primary" textAlign="center">
+          <Download />
+        </Button>
+      }
+    />
+  ))
+  .add("with custom toggle button options", () => (
+    <Dropdown
+      onChange={noop}
+      items={items}
+      customToggleButtonOptions={{
+        iconPosition: "left",
+        size: "small",
+        type: "unstyled-link",
+      }}
+    >
+      Select options
+    </Dropdown>
+  ));

--- a/src/dropdown/dropdown.tsx
+++ b/src/dropdown/dropdown.tsx
@@ -1,168 +1,153 @@
-/* eslint-disable @typescript-eslint/camelcase */
 import React from "react";
-import Select from "react-select";
-import classNames from "classnames/bind";
-import _ from "lodash";
+import classnames from "classnames/bind";
 
-import { CaretDown, CaretLeft, CaretRight } from "@cockroachlabs/icons";
-import "react-select/scss/default.scss";
+import { OutsideEventHandler } from "../outsideEventHandler";
 import styles from "./dropdown.module.scss";
+import { Button, ButtonProps } from "src/button";
+import { CaretDown } from "@cockroachlabs/icons";
 
-export interface DropdownOption {
-  value: string;
-  label: string;
+const cx = classnames.bind(styles);
+
+export interface DropdownOption<T = string> {
+  value: T;
+  name: React.ReactNode | string;
 }
 
-export enum ArrowDirection {
-  LEFT,
-  RIGHT,
-  CENTER,
-}
-
-interface DropdownOwnProps {
-  title: string;
-  selected: string;
-  options: DropdownOption[];
-  onChange?: (selected: DropdownOption) => void; // Callback when the value changes.
-  // If onArrowClick exists, don't display the arrow next to the dropdown,
-  // display left and right arrows to either side instead.
-  onArrowClick?: (direction: ArrowDirection) => void;
-  // Disable any arrows in the arrow direction array.
-  disabledArrows?: ArrowDirection[];
-  content?: any;
-  isTimeRange?: boolean;
+export interface DropdownProps<T> {
+  items: Array<DropdownOption<T>>;
+  onChange: (item: DropdownOption<T>["value"]) => void;
+  children?: React.ReactNode;
+  customToggleButton?: React.ReactNode;
+  customToggleButtonOptions?: Partial<ButtonProps>;
+  menuPosition?: "left" | "right";
   className?: string;
-  type?: "primary" | "secondary";
 }
 
-const cx = classNames.bind(styles);
+interface DropdownState {
+  isOpen: boolean;
+}
 
-export const arrowRenderer = ({ isOpen }: { isOpen: boolean }) => (
-  <span className={cx("caret-down", { active: isOpen })}>
-    <CaretDown className={cx("dropdown-caret")} />
-  </span>
-);
+interface DropdownButtonProps {
+  children: React.ReactNode;
+  isOpen: boolean;
+  onClick?: (event: React.MouseEvent<HTMLElement>) => void;
+  customProps?: Partial<ButtonProps>;
+}
 
-/**
- * Dropdown component that uses the URL query string for state.
- */
-export class Dropdown extends React.Component<DropdownOwnProps, {}> {
+const DropdownButton: React.FC<DropdownButtonProps> = ({
+  children,
+  customProps = {},
+}) => {
+  return (
+    <Button
+      type="secondary"
+      size="default"
+      iconPosition="right"
+      icon={<CaretDown />}
+      {...customProps}
+    >
+      {children}
+    </Button>
+  );
+};
+
+function DropdownItem<T = string>(props: DropdownItemProps<T>) {
+  const { children, value, onClick } = props;
+  return (
+    <div onClick={() => onClick(value)} className={cx("crl-dropdown__item")}>
+      {children}
+    </div>
+  );
+}
+
+export class Dropdown<T = string> extends React.Component<
+  DropdownProps<T>,
+  DropdownState
+> {
   state = {
-    is_focused: false,
+    isOpen: false,
   };
 
-  dropdownRef: React.RefObject<HTMLDivElement> = React.createRef();
-  titleRef: React.RefObject<HTMLDivElement> = React.createRef();
-  selectRef: React.RefObject<Select> = React.createRef();
+  handleMenuOpen = () => {
+    this.setState({
+      isOpen: !this.state.isOpen,
+    });
+  };
 
-  triggerSelectClick = (e: any) => {
-    const dropdownNode = this.dropdownRef.current as Node;
-    const titleNode = this.titleRef.current as Node;
-    const selectNode = this.selectRef.current;
+  changeMenuState = (nextState: boolean) => {
+    this.setState({
+      isOpen: nextState,
+    });
+  };
 
-    if (
-      e.target.isSameNode(dropdownNode) ||
-      e.target.isSameNode(titleNode) ||
-      e.target.className.indexOf("dropdown__select") > -1
-    ) {
-      // This is a far-less-than-ideal solution to the need to trigger
-      // the react-select dropdown from the entirety of the dropdown area
-      // instead of just the nodes rendered by the component itself
-      // the approach borrows from:
-      // https://github.com/JedWatson/react-select/issues/305#issuecomment-172607534
-      //
-      // a broader discussion on the status of a possible feature addition that
-      // would render this hack moot can be found here:
-      // https://github.com/JedWatson/react-select/issues/1989
-      (selectNode as any).handleMouseDownOnMenu(e);
+  handleItemSelection = (value: T) => {
+    this.props.onChange(value);
+    this.handleMenuOpen();
+  };
+
+  renderDropdownToggleButton = () => {
+    const {
+      children,
+      customToggleButton,
+      customToggleButtonOptions,
+    } = this.props;
+    const { isOpen } = this.state;
+
+    if (customToggleButton) {
+      return customToggleButton;
+    } else {
+      return (
+        <DropdownButton isOpen={isOpen} customProps={customToggleButtonOptions}>
+          {children}
+        </DropdownButton>
+      );
     }
   };
 
-  onFocus = () => this.setState({ is_focused: true });
-
-  onClose = () => this.setState({ is_focused: false });
-
   render() {
-    const {
-      selected,
-      options,
-      onChange,
-      onArrowClick,
-      disabledArrows,
-      content,
-      isTimeRange,
-      type = "secondary",
-    } = this.props;
+    const { items, menuPosition = "left", className } = this.props;
+    const { isOpen } = this.state;
 
-    const className = cx(
-      "dropdown",
-      `dropdown--type-${type}`,
+    const menuStyles = cx(
+      "crl-dropdown__menu",
+      `crl-dropdown__menu--align-${menuPosition}`,
       {
-        _range: isTimeRange,
-        "dropdown--side-arrows": !_.isNil(onArrowClick),
-        dropdown__focused: this.state.is_focused,
+        "crl-dropdown__menu--open": isOpen,
       },
-      this.props.className,
     );
-    const leftClassName = cx("dropdown__side-arrow", {
-      "dropdown__side-arrow--disabled": _.includes(
-        disabledArrows,
-        ArrowDirection.LEFT,
-      ),
-    });
-    const rightClassName = cx("dropdown__side-arrow", {
-      "dropdown__side-arrow--disabled": _.includes(
-        disabledArrows,
-        ArrowDirection.RIGHT,
-      ),
-    });
+
+    const menuItems = items.map((menuItem, idx) => (
+      <DropdownItem<T>
+        value={menuItem.value}
+        onClick={this.handleItemSelection}
+        key={idx}
+      >
+        {menuItem.name}
+      </DropdownItem>
+    ));
 
     return (
-      <div
-        className={className}
-        onClick={this.triggerSelectClick}
-        ref={this.dropdownRef}
-      >
-        {/* TODO (maxlang): consider moving arrows outside the dropdown component */}
-        <span
-          className={leftClassName}
-          onClick={() => this.props.onArrowClick(ArrowDirection.LEFT)}
-        >
-          <CaretLeft className={cx("dropdown-caret")} />
-        </span>
-        <span
-          className={cx({
-            "dropdown__range-title": isTimeRange,
-            dropdown__title: !isTimeRange,
-          })}
-          ref={this.titleRef}
-        >
-          {this.props.title}
-          {this.props.title && !isTimeRange ? ":" : ""}
-        </span>
-        {content ? (
-          content
-        ) : (
-          <Select
-            className={cx("dropdown__select")}
-            arrowRenderer={arrowRenderer}
-            clearable={false}
-            searchable={false}
-            options={options}
-            value={selected}
-            onChange={onChange}
-            onFocus={this.onFocus}
-            onClose={this.onClose}
-            ref={this.selectRef}
-          />
-        )}
-        <span
-          className={rightClassName}
-          onClick={() => this.props.onArrowClick(ArrowDirection.RIGHT)}
-        >
-          <CaretRight className={cx("dropdown-caret")} />
-        </span>
+      <div className={cx("crl-dropdown", className)}>
+        <OutsideEventHandler onOutsideClick={() => this.changeMenuState(false)}>
+          <div
+            className={cx("crl-dropdown__handler")}
+            onClick={this.handleMenuOpen}
+          >
+            {this.renderDropdownToggleButton()}
+          </div>
+          <div className={cx("crl-dropdown__overlay")}>
+            <div className={menuStyles}>
+              <div className={cx("crl-dropdown__container")}>{menuItems}</div>
+            </div>
+          </div>
+        </OutsideEventHandler>
       </div>
     );
   }
+}
+
+export interface DropdownItemProps<T> {
+  children: React.ReactNode;
+  value: T;
+  onClick: (value: T) => void;
 }

--- a/src/outsideEventHandler/index.tsx
+++ b/src/outsideEventHandler/index.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import classNames from "classnames/bind";
+
+import styles from "./outsideEventHandler.module.scss";
+
+const cx = classNames.bind(styles);
+
+export interface OutsideEventHandlerProps {
+  onOutsideClick: () => void;
+  children: any;
+  mountNodePosition?: "fixed" | "initial";
+  ignoreClickOnRefs?: React.RefObject<HTMLDivElement>[];
+}
+
+export class OutsideEventHandler extends React.Component<
+  OutsideEventHandlerProps
+> {
+  nodeRef: React.RefObject<HTMLDivElement>;
+
+  constructor(props: any) {
+    super(props);
+    this.nodeRef = React.createRef();
+  }
+
+  componentDidMount() {
+    this.addEventListener();
+  }
+
+  componentWillUnmount() {
+    this.removeEventListener();
+  }
+
+  onClick = (event: any) => {
+    const { onOutsideClick, ignoreClickOnRefs = [] } = this.props;
+    const isChildEl =
+      this.nodeRef.current && this.nodeRef.current.contains(event.target);
+
+    const isOutsideIgnoredEl = ignoreClickOnRefs.some(outsideIgnoredRef => {
+      if (!outsideIgnoredRef || !outsideIgnoredRef.current) {
+        return false;
+      }
+      return outsideIgnoredRef.current.contains(event.target);
+    });
+
+    if (!isChildEl && !isOutsideIgnoredEl) {
+      onOutsideClick();
+    }
+  };
+
+  addEventListener = () => {
+    addEventListener("click", this.onClick);
+  };
+
+  removeEventListener = () => {
+    removeEventListener("click", this.onClick);
+  };
+
+  render() {
+    const { children, mountNodePosition = "initial" } = this.props;
+    const classes = cx(
+      "outside-event-handler",
+      `outside-event-handler--position-${mountNodePosition}`,
+    );
+
+    return (
+      <div ref={this.nodeRef} className={classes}>
+        {children}
+      </div>
+    );
+  }
+}

--- a/src/outsideEventHandler/outsideEventHandler.module.scss
+++ b/src/outsideEventHandler/outsideEventHandler.module.scss
@@ -1,0 +1,11 @@
+.outside-event-handler {
+  position: initial;
+}
+
+.outside-event-handler--position-fixed {
+  position: fixed;
+}
+
+.outside-event-handler--position-initial {
+  position: initial;
+}

--- a/src/statementsDiagnostics/diagnosticStatusBadge.tsx
+++ b/src/statementsDiagnostics/diagnosticStatusBadge.tsx
@@ -17,7 +17,7 @@ function mapDiagnosticsStatusToBadge(diagnosticsStatus: DiagnosticStatuses) {
   switch (diagnosticsStatus) {
     case "READY":
       return "success";
-    case "WAITING FOR QUERY":
+    case "WAITING":
       return "info";
     case "ERROR":
       return "danger";
@@ -42,7 +42,7 @@ function mapStatusToDescription(diagnosticsStatus: DiagnosticStatuses) {
           </p>
         </div>
       );
-    case "WAITING FOR QUERY":
+    case "WAITING":
       return (
         <div className={cx("tooltip__table--title")}>
           <p>

--- a/src/statementsDiagnostics/diagnosticStatuses.ts
+++ b/src/statementsDiagnostics/diagnosticStatuses.ts
@@ -1,1 +1,1 @@
-export type DiagnosticStatuses = "READY" | "WAITING FOR QUERY" | "ERROR";
+export type DiagnosticStatuses = "READY" | "WAITING" | "ERROR";

--- a/src/statementsPage/statementsPage.fixture.ts
+++ b/src/statementsPage/statementsPage.fixture.ts
@@ -2,7 +2,10 @@
 import { StatementsPageProps } from "./statementsPage";
 import { createMemoryHistory } from "history";
 import Long from "long";
+import { noop } from "lodash";
 import * as protos from "@cockroachlabs/crdb-protobuf-client";
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+type IStatementDiagnosticsReport = cockroach.server.serverpb.IStatementDiagnosticsReport;
 type IStatementStatistics = protos.cockroach.sql.IStatementStatistics;
 
 const history = createMemoryHistory({ initialEntries: ["/statements"]});
@@ -145,6 +148,40 @@ const statementStats: IStatementStatistics = {
   },
 };
 
+const diagnosticsReports: IStatementDiagnosticsReport[] = [
+  {
+    "id": Long.fromNumber(594413966918975489),
+    "completed": true,
+    "statement_fingerprint": "SHOW database",
+    "statement_diagnostics_id": Long.fromNumber(594413981435920385),
+    "requested_at": {"seconds": Long.fromNumber(1601471146), "nanos": 737251000}
+  },
+  {
+    "id": Long.fromNumber(594413966918975429),
+    "completed": true,
+    "statement_fingerprint": "SHOW database",
+    "statement_diagnostics_id": Long.fromNumber(594413281435920385),
+    "requested_at": {"seconds": Long.fromNumber(1601491146), "nanos": 737251000}
+  }
+]
+
+const diagnosticsReportsInProgress: IStatementDiagnosticsReport[] = [
+  {
+    "id": Long.fromNumber(594413966918975489),
+    "completed": false,
+    "statement_fingerprint": "SHOW database",
+    "statement_diagnostics_id": Long.fromNumber(594413981435920385),
+    "requested_at": {"seconds": Long.fromNumber(1601471146), "nanos": 737251000}
+  },
+  {
+    "id": Long.fromNumber(594413966918975429),
+    "completed": true,
+    "statement_fingerprint": "SHOW database",
+    "statement_diagnostics_id": Long.fromNumber(594413281435920385),
+    "requested_at": {"seconds": Long.fromNumber(1601491146), "nanos": 737251000}
+  }
+]
+
 const statementsPagePropsFixture: StatementsPageProps = {
   history,
   location: {
@@ -234,6 +271,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
       "label": "SHOW database",
       "implicitTxn": true,
       "stats": statementStats,
+      diagnosticsReports,
     },
     {
       "label": "CREATE TABLE IF NOT EXISTS promo_codes (code VARCHAR NOT NULL, description VARCHAR NULL, creation_time TIMESTAMP NULL, expiration_time TIMESTAMP NULL, rules JSONB NULL, PRIMARY KEY (code ASC))",
@@ -324,6 +362,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
       "label": "CREATE DATABASE movr",
       "implicitTxn": true,
       "stats": statementStats,
+      diagnosticsReports: diagnosticsReportsInProgress
     },
     {
       "label": "SELECT count(*) > _ FROM [SHOW ALL CLUSTER SETTINGS] AS _ (v) WHERE v = _",
@@ -379,11 +418,13 @@ const statementsPagePropsFixture: StatementsPageProps = {
   ],
   "totalFingerprints": 95,
   "lastReset": "2020-04-13 07:22:23",
-  dismissAlertMessage: () => {},
-  refreshStatementDiagnosticsRequests: () => {},
-  refreshStatements: () => {},
-  onActivateStatementDiagnostics: _statement => {},
-  onDiagnosticsModalOpen: () => {},
+  dismissAlertMessage: noop,
+  refreshStatementDiagnosticsRequests: noop,
+  refreshStatements: noop,
+  onActivateStatementDiagnostics: noop,
+  onDiagnosticsModalOpen: noop,
+  onSearchComplete: noop,
+  onDiagnosticsReportDownload: noop,
 };
 
 export default statementsPagePropsFixture;

--- a/src/statementsPage/statementsPage.tsx
+++ b/src/statementsPage/statementsPage.tsx
@@ -9,12 +9,13 @@ import classNames from "classnames/bind";
 import {
   paginationPageCount,
   Dropdown,
-  DropdownOption,
   Loading,
   PageConfig,
   PageConfigItem,
   SortSetting,
   Search,
+  Text,
+  TextTypes,
 } from "src/index";
 import { DATE_FORMAT, appAttr, getMatchParamByName } from "src/util";
 import {
@@ -135,9 +136,9 @@ export class StatementsPage extends React.Component<
     );
   };
 
-  selectApp = (app: DropdownOption) => {
+  selectApp = (value: string) => {
     const { history } = this.props;
-    history.location.pathname = `/statements/${encodeURIComponent(app.value)}`;
+    history.location.pathname = `/statements/${encodeURIComponent(value)}`;
     history.replace(history.location);
     this.resetPagination();
   };
@@ -241,8 +242,9 @@ export class StatementsPage extends React.Component<
     const { statements, match } = this.props;
     const appAttrValue = getMatchParamByName(match, appAttr);
     const selectedApp = appAttrValue || "";
-    const appOptions = [{ value: "", label: "All" }];
-    this.props.apps.forEach(app => appOptions.push({ value: app, label: app }));
+    const appOptions = [{ value: "", name: "All" }];
+    this.props.apps.forEach(app => appOptions.push({ value: app, name: app }));
+    const currentOption = appOptions.find(o => o.value === selectedApp);
     const data = this.filteredStatementsData();
     const totalCount = data.length;
     const isEmptySearchResults = statements?.length > 0 && search?.length > 0;
@@ -258,12 +260,11 @@ export class StatementsPage extends React.Component<
             />
           </PageConfigItem>
           <PageConfigItem>
-            <Dropdown
-              title="App"
-              options={appOptions}
-              selected={decodeURIComponent(selectedApp)}
-              onChange={this.selectApp}
-            />
+            <Dropdown items={appOptions} onChange={this.selectApp}>
+              <Text textType={TextTypes.BodyStrong}>
+                {`App: ${decodeURIComponent(currentOption.name)}`}
+              </Text>
+            </Dropdown>
           </PageConfigItem>
         </PageConfig>
         <section className={sortableTableCx("cl-table-container")}>

--- a/src/statementsPage/statementsPage.tsx
+++ b/src/statementsPage/statementsPage.tsx
@@ -31,6 +31,9 @@ import { ISortedTablePagination } from "../sortedtable";
 import styles from "./statementsPage.module.scss";
 import sortableTableStyles from "../sortabletable/sortabletable.module.scss";
 import { EmptyStatementsPlaceholder } from "./emptyStatementsPlaceholder";
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+
+type IStatementDiagnosticsReport = cockroach.server.serverpb.IStatementDiagnosticsReport;
 
 const cx = classNames.bind(styles);
 const sortableTableCx = classNames.bind(sortableTableStyles);
@@ -46,6 +49,7 @@ interface OwnProps {
   dismissAlertMessage: () => void;
   onActivateStatementDiagnostics: (statement: string) => void;
   onDiagnosticsModalOpen: (statement: string) => void;
+  onDiagnosticsReportDownload?: (report: IStatementDiagnosticsReport) => void;
   onSearchComplete?: (results: AggregateStatistics[]) => void;
   onPageChanged?: (newPage: number) => void;
   onSortingChange?: (
@@ -239,7 +243,7 @@ export class StatementsPage extends React.Component<
 
   renderStatements = () => {
     const { pagination, search } = this.state;
-    const { statements, match } = this.props;
+    const { statements, match, onDiagnosticsReportDownload } = this.props;
     const appAttrValue = getMatchParamByName(match, appAttr);
     const selectedApp = appAttrValue || "";
     const appOptions = [{ value: "", name: "All" }];
@@ -289,6 +293,7 @@ export class StatementsPage extends React.Component<
               selectedApp,
               search,
               this.activateDiagnosticsRef,
+              onDiagnosticsReportDownload,
             )}
             sortSetting={this.state.sortSetting}
             onChangeSortSetting={this.changeSortSetting}

--- a/src/statementsTable/statementsTableContent.module.scss
+++ b/src/statementsTable/statementsTableContent.module.scss
@@ -60,3 +60,23 @@
     text-decoration: underline;
   }
 }
+
+.activate-diagnostic-col {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  align-items: center;
+
+  .activate-diagnostic-link {
+    width: auto!important;
+  }
+
+  .activate-diagnostic-dropdown {
+    margin-left: $spacing-base;
+  }
+
+  .download-diagnostics-link {
+    color: inherit;
+    text-decoration: inherit;
+  }
+}

--- a/src/statementsTable/statementsTableContent.tsx
+++ b/src/statementsTable/statementsTableContent.tsx
@@ -1,11 +1,15 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import classNames from "classnames/bind";
+import { noop } from "lodash";
 import {
   Anchor,
   ActivateDiagnosticsModalRef,
   getHighlightedText,
   DiagnosticStatusBadge,
+  AggregateStatistics,
+  Dropdown,
+  Button,
 } from "src/index";
 import { Tooltip2 as Tooltip } from "src/tooltip2";
 import {
@@ -15,13 +19,16 @@ import {
   statementsTimeInterval,
   transactionalPipelining,
   summarize,
+  TimestampToMoment,
 } from "src/util";
 import { shortStatement } from "./statementsTable";
 import styles from "./statementsTableContent.module.scss";
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+import { Download } from "@cockroachlabs/icons";
 
 export type NodeNames = { [nodeId: string]: string };
-
 const cx = classNames.bind(styles);
+type IStatementDiagnosticsReport = cockroach.server.serverpb.IStatementDiagnosticsReport;
 
 export const StatementTableTitle = {
   statements: (
@@ -200,24 +207,68 @@ export const StatementTableCell = {
   ),
   diagnostics: (
     activateDiagnosticsRef: React.RefObject<ActivateDiagnosticsModalRef>,
-  ) => (stmt: any) => {
-    if (stmt.diagnosticsReport) {
-      return (
-        <DiagnosticStatusBadge
-          status={
-            stmt.diagnosticsReport.completed ? "READY" : "WAITING FOR QUERY"
-          }
-        />
-      );
-    }
+    onDiagnosticsDownload: (report: IStatementDiagnosticsReport) => void = noop,
+  ) => (stmt: AggregateStatistics) => {
+    /*
+     * Diagnostics cell might display different components depending
+     * on following states:
+     * - show `Activate` link only if no completed or waiting reports available;
+     * - show `WAITING` badge only if report requested for the first time;
+     * - show `WAITING` badge and dropdown with download links if report is currently
+     * requested and previous reports are available for download;
+     * - show `Activate` link and dropdown with download links if there is completed
+     * reports only;
+     * */
+    const hasDiagnosticReports = !!stmt.diagnosticsReports;
+    const hasCompletedDiagnosticsReports =
+      hasDiagnosticReports && stmt.diagnosticsReports.some(d => d.completed);
+    const canActivateDiagnosticReport = hasDiagnosticReports
+      ? stmt.diagnosticsReports.every(d => d.completed)
+      : true;
+
     return (
-      <Anchor
-        onClick={() =>
-          activateDiagnosticsRef?.current?.showModalFor(stmt.label)
-        }
-      >
-        Activate
-      </Anchor>
+      <div className={cx("activate-diagnostic-col")}>
+        {canActivateDiagnosticReport ? (
+          <Button
+            onClick={() =>
+              activateDiagnosticsRef?.current?.showModalFor(stmt.label)
+            }
+            type="secondary"
+            size="small"
+          >
+            Activate
+          </Button>
+        ) : (
+          <DiagnosticStatusBadge status="WAITING" />
+        )}
+        {hasCompletedDiagnosticsReports && (
+          <Dropdown<IStatementDiagnosticsReport>
+            items={stmt.diagnosticsReports
+              .filter(dr => dr.completed)
+              .map(dr => ({
+                name: (
+                  <a
+                    className={cx("download-diagnostics-link")}
+                    href={`_admin/v1/stmtbundle/${dr.statement_diagnostics_id}`}
+                  >
+                    {`${TimestampToMoment(dr.requested_at).format(
+                      "ll [at] LT [diagnostic]",
+                    )}`}
+                  </a>
+                ),
+                value: dr,
+              }))}
+            onChange={onDiagnosticsDownload}
+            menuPosition="right"
+            customToggleButtonOptions={{
+              size: "small",
+              icon: <Download />,
+              textAlign: "center",
+            }}
+            className={cx("activate-diagnostic-dropdown")}
+          />
+        )}
+      </div>
     );
   },
   nodeLink: (nodeNames: NodeNames) => (stmt: any) => (

--- a/src/util/convert.ts
+++ b/src/util/convert.ts
@@ -1,0 +1,52 @@
+import moment from "moment";
+
+import * as protos from "@cockroachlabs/crdb-protobuf-client";
+
+/**
+ * NanoToMilli converts a nanoseconds value into milliseconds.
+ */
+export function NanoToMilli(nano: number): number {
+  return nano / 1.0e6;
+}
+
+/**
+ * MilliToNano converts a millisecond value into nanoseconds.
+ */
+export function MilliToNano(milli: number): number {
+  return milli * 1.0e6;
+}
+
+/**
+ * SecondsToNano converts a second value into nanoseconds.
+ */
+export function SecondsToNano(sec: number): number {
+  return sec * 1.0e9;
+}
+
+/**
+ * TimestampToMoment converts a Timestamp$Properties object, as seen in wire.proto, to
+ * a Moment object. If timestamp is null, it returns the `defaultsIfNull` value which is
+ * by default is current time.
+ */
+export function TimestampToMoment(
+  timestamp?: protos.google.protobuf.ITimestamp,
+  defaultsIfNull = moment.utc(),
+): moment.Moment {
+  if (!timestamp) {
+    return defaultsIfNull;
+  }
+  return moment.utc(
+    timestamp.seconds.toNumber() * 1e3 + NanoToMilli(timestamp.nanos),
+  );
+}
+
+/**
+ * LongToMoment converts a Long, representing nanos since the epoch, to a Moment
+ * object. If timestamp is null, it returns the current time.
+ */
+export function LongToMoment(timestamp: Long): moment.Moment {
+  if (!timestamp) {
+    return moment.utc();
+  }
+  return moment.utc(NanoToMilli(timestamp.toNumber()));
+}

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,5 +1,6 @@
 export * from "./appStats";
 export * from "./constants";
+export * from "./convert";
 export * from "./dataFromServer";
 export * from "./docs";
 export * from "./fixLong";


### PR DESCRIPTION
Related to https://github.com/cockroachdb/cockroach/issues/50824

Previously, statement diagnostics could only be triggered from
Statements page and it wasn't possible to download. Also when
first diagnostics report is generated, then `Activate` button
wasn't available at all.

Now, Diagnostics column allows users to request diagnostics
reports when all previous reports are generated and allow
to download all previously generated reports from the list.

![Screen Shot 2020-10-01 at 4 55 32 PM](https://user-images.githubusercontent.com/3106437/94912361-38491180-04b0-11eb-95fa-ad71a8381cc0.png)

With rewritten Dropdown component, it is necessary to
adjust its usage across the current package.
Currently, it is used only in one place so this changes
aren't global.

![Screen Shot 2020-10-01 at 4 55 16 PM](https://user-images.githubusercontent.com/3106437/94912847-eeacf680-04b0-11eb-8c77-be6002be276c.png)
