### PR TITLE
fix styles for cells with links in sortable table

### DIFF
--- a/src/barCharts/barCharts.module.scss
+++ b/src/barCharts/barCharts.module.scss
@@ -24,7 +24,7 @@
   &__label {
     position: relative;
     font-family: $font-family--base;
-    font-size: 12px;
+    font-size: $font-size--medium;
     line-height: 1.83;
     color: $colors--neutral-8;
     width: 75px;

--- a/src/empty/emptyTable/emptyTable.stories.tsx
+++ b/src/empty/emptyTable/emptyTable.stories.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import { storiesOf } from "@storybook/react";
 
 import { EmptyTable } from "./emptyTable";
-import emptyListResultsImg from "../assets/emptyState/empty-list-results.svg";
-import notFoundImg from "../assets/emptyState/not-found-404.svg";
+import emptyListResultsImg from "../../assets/emptyState/empty-list-results.svg";
+import notFoundImg from "../../assets/emptyState/not-found-404.svg";
 import { Button } from "src";
 import SpinIcon from "../../icon/spin";
 

--- a/src/sortabletable/table.module.scss
+++ b/src/sortabletable/table.module.scss
@@ -13,14 +13,14 @@ $stats-table-tr--bg: $colors--neutral-0;
   font-family: $font-family--base;
   font-weight: 300;
   line-height: 22px;
-  font-size: 14px;
+  font-size: $font-size--medium;
   vertical-align: top;
-  color: $stats-table-td--fg;
+  color: $colors--neutral-7;
 
   &__row {
     &--body {
       letter-spacing: 0.33px;
-      background-color: $stats-table-tr--bg;
+      background-color: $colors--neutral-0;
       &:hover {
         background-color: $colors--background;
       }
@@ -28,7 +28,7 @@ $stats-table-tr--bg: $colors--neutral-0;
 
     &--header {
       padding: 20px;
-      font-size: 12px;
+      font-size: $font-size--medium;
       font-weight: bold;
       letter-spacing: 2px;
       text-transform: uppercase;
@@ -40,14 +40,14 @@ $stats-table-tr--bg: $colors--neutral-0;
     &--summary {
       background-color: $colors--background;
       font-family: $font-family--semi-bold;
-      font-size: 14px;
+      font-size: $font-size--medium;
       font-weight: bold;
       line-height: 1.71;
       letter-spacing: 0.1px;
       color: $colors--neutral-7;
       .bar-chart .label {
         font-family: $font-family--semi-bold;
-        font-size: 14px;
+        font-size: $font-size--medium;
         font-weight: bold;
         line-height: 1.71;
         letter-spacing: 0.1px;
@@ -62,11 +62,14 @@ $stats-table-tr--bg: $colors--neutral-0;
     font-weight: inherit;
 
     a {
-      font-weight: 400;
-      color: $colors--primary-blue-3;
+      color: $adminui-grey-1;
       text-decoration: none;
-      width: 100%;
-      height: 100%;
+      cursor: pointer;
+
+      &:hover {
+        color: $colors--primary-blue-3;
+        text-decoration: underline;
+      }
     }
 
     &--filler {

--- a/src/statementsTable/statementsTable.module.scss
+++ b/src/statementsTable/statementsTable.module.scss
@@ -39,13 +39,8 @@
 .cl-table__col-query-text a {
   font-family: $font-family--monospace;
   font-size: 12px;
-  line-height: 1.83;
-  color: $colors--neutral-8;
   width: 400px;
-  text-decoration: none;
-  cursor: pointer;
-  &:hover {
-    color: $colors--primary-blue-3;
-    text-decoration: underline;
+  div {
+    font-size: $font-size--small;
   }
 }

--- a/src/statementsTable/statementsTableContent.module.scss
+++ b/src/statementsTable/statementsTableContent.module.scss
@@ -47,20 +47,6 @@
   }
 }
 
-.cl-table__col-query-text a {
-  font-family: $font-family--monospace;
-  font-size: 12px;
-  line-height: 1.83;
-  color: $colors--neutral-8;
-  width: 400px;
-  text-decoration: none;
-  cursor: pointer;
-  &:hover{
-    color: $colors--primary-blue-3;
-    text-decoration: underline;
-  }
-}
-
 .activate-diagnostic-col {
   display: flex;
   flex-direction: row;
@@ -77,6 +63,10 @@
 
   .download-diagnostics-link {
     color: inherit;
-    text-decoration: inherit;
+    text-decoration: none;
+    &:hover {
+      color: inherit;
+      text-decoration: none;
+    }
   }
 }


### PR DESCRIPTION
Regression of styles in sortable table and consequently in
statements table was introduced during statements page extraction.
Links in table has to be by default with black colored and change
color to blue on hover. Also font-size for text cells was incorrect,
12px instead of required 14px.

Current fix applies these styles 
on base elements with some cleanup
for styles.

Relevant to issue https://github.com/cockroachdb/cockroach/issues/54513

![Screen Shot 2020-10-12 at 2 57 42 PM](https://user-images.githubusercontent.com/3106437/95744225-af925880-0c9b-11eb-9449-8fba7423b4e5.png)