### PR TITLE
custom base path for statements api

### DIFF
--- a/src/statementsPage/api/statementsApi.ts
+++ b/src/statementsPage/api/statementsApi.ts
@@ -1,11 +1,13 @@
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { fetchData } from "src/api";
 
-const STATEMENTS_PATH = "_status/statements";
+const STATEMENTS_PATH = "/_status/statements";
 
-export const getStatements = (): Promise<cockroach.server.serverpb.StatementsResponse> => {
+export const getStatements = (
+  basePath = "",
+): Promise<cockroach.server.serverpb.StatementsResponse> => {
   return fetchData(
     cockroach.server.serverpb.StatementsResponse,
-    STATEMENTS_PATH,
+    `${basePath}${STATEMENTS_PATH}`,
   );
 };

--- a/src/statementsPage/components/statementsPage.tsx
+++ b/src/statementsPage/components/statementsPage.tsx
@@ -57,7 +57,6 @@ interface OwnProps {
     columnTitle: string,
     ascending: boolean,
   ) => void;
-  basePath?: string;
 }
 
 export interface StatementsPageState {

--- a/src/statementsPage/components/statementsPageConnected.tsx
+++ b/src/statementsPage/components/statementsPageConnected.tsx
@@ -41,10 +41,7 @@ type MapDispatchToProps = Pick<
   | "onSortingChange"
 >;
 
-type OwnProps = Pick<
-  StatementsPageProps,
-  "basePath" | "onDiagnosticsReportDownload"
-> &
+type OwnProps = Pick<StatementsPageProps, "onDiagnosticsReportDownload"> &
   RouteComponentProps;
 
 export const ConnectedStatementsPage = withRouter(

--- a/src/statementsPage/store/index.ts
+++ b/src/statementsPage/store/index.ts
@@ -33,10 +33,13 @@ export const statementsReducersMap: ReducersMapObject<StateWithStatements["admin
 
 export const statementsReducers = combineReducers(statementsReducersMap);
 
-export function* statementsSagas() {
+export function* statementsSagas(
+  cacheInvalidationPeriod?: number,
+  apiBasePath?: string,
+) {
   yield all([
     fork(localStorageSaga),
-    fork(statementsSaga),
+    fork(statementsSaga, cacheInvalidationPeriod, apiBasePath),
     fork(statementsDiagnosticsSagas),
   ]);
 }

--- a/src/statementsPage/store/statementsPage.sagas.spec.ts
+++ b/src/statementsPage/store/statementsPage.sagas.spec.ts
@@ -1,6 +1,6 @@
-import { expectSaga } from "redux-saga-test-plan";
+import { expectSaga, testSaga } from "redux-saga-test-plan";
 import { throwError } from "redux-saga-test-plan/providers";
-import { call } from "redux-saga/effects";
+import * as matchers from "redux-saga-test-plan/matchers";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import statementsReducer, {
   invalidateStatements,
@@ -33,7 +33,7 @@ describe("StatementsPage sagas", () => {
   describe("requestStatementsSaga", () => {
     it("successfully requests statements list", () => {
       expectSaga(requestStatementsSaga)
-        .provide([[call(getStatements), statements]])
+        .provide([[matchers.call.fn(getStatements), statements]])
         .put(statementsReceived(statements))
         .withReducer(statementsReducer)
         .hasFinalState<StatementsState>({
@@ -47,7 +47,7 @@ describe("StatementsPage sagas", () => {
     it("returns error on failed request", () => {
       const error = new Error("Failed request");
       expectSaga(requestStatementsSaga)
-        .provide([[call(getStatements), throwError(error)]])
+        .provide([[matchers.call.fn(getStatements), throwError(error)]])
         .put(statementsRequestFailed(error))
         .withReducer(statementsReducer)
         .hasFinalState<StatementsState>({
@@ -56,6 +56,14 @@ describe("StatementsPage sagas", () => {
           valid: false,
         })
         .run();
+    });
+
+    it("accepts custom apiPath as an argument for statements api", () => {
+      const customBasePath = "customBasePath";
+      testSaga(requestStatementsSaga, customBasePath)
+        .next()
+        .call(getStatements, customBasePath)
+        .finish();
     });
   });
 


### PR DESCRIPTION
Resolves #36

Before, statements page relied on a fact that it has to have
"/" base path and all api requests.

Now, it is needed to render Statements page with custom base path,
so statements api has to accept provided base path from outside.

All API calls are dispatched from sagas (as the only way for side-effects),
and `basePath` is provided as an optional argument to root saga which then
propagates basePath to all sagas which call api.

Current change doesn't break previous functionality and fully backward
compatible.