### PR TITLE
fix barCharts rendering for zero values

### DIFF
--- a/src/barCharts/barChartFactory.tsx
+++ b/src/barCharts/barChartFactory.tsx
@@ -6,6 +6,7 @@ import { Tooltip } from "src/index";
 import classNames from "classnames/bind";
 import styles from "./barCharts.module.scss";
 import { NumericStatLegend } from "./numericStatLegend";
+import { normalizeClosedDomain } from "./utils";
 
 const cx = classNames.bind(styles);
 
@@ -41,14 +42,14 @@ export function barChartFactory<T>(
       rows,
       stdDevAccessor ? getTotalWithStdDev : getTotal,
     );
-
+    const domain = normalizeClosedDomain([0, extent[1]]);
     const scale = scaleLinear()
-      .domain([0, extent[1]])
+      .domain(domain)
       .range([0, 100]);
 
     return (d: T) => {
       if (rows.length === 0) {
-        scale.domain([0, getTotal(d)]);
+        scale.domain(normalizeClosedDomain([0, getTotal(d)]));
       }
 
       let sum = 0;

--- a/src/barCharts/barCharts.stories.tsx
+++ b/src/barCharts/barCharts.stories.tsx
@@ -8,6 +8,7 @@ import {
   rowsBarChart,
 } from "./barCharts";
 import statementsPagePropsFixture from "src/statementsPage/components/statementsPage.fixture";
+import Long from "long";
 
 const { statements } = statementsPagePropsFixture;
 
@@ -66,6 +67,19 @@ storiesOf("BarCharts/within column (150px)", module)
   .add("retryBarChart", () => {
     const chartFactory = retryBarChart(statements);
     return chartFactory(statements[0]);
+  })
+  .add("empty retryBarChart", () => {
+    const withoutRetries = statements.map(s => ({
+      ...s,
+      stats: {
+        ...s.stats,
+        count: Long.fromNumber(0),
+        first_attempt_count: Long.fromNumber(0),
+        max_retries: Long.fromNumber(0),
+      },
+    }));
+    const chartFactory = retryBarChart(withoutRetries);
+    return chartFactory(withoutRetries[0]);
   })
   .add("rowsBarChart", () => {
     const chartFactory = rowsBarChart(statements);

--- a/src/barCharts/latencyBreakdown.tsx
+++ b/src/barCharts/latencyBreakdown.tsx
@@ -7,7 +7,7 @@ import { Duration } from "src/util/format";
 import { Tooltip } from "src/index";
 import classNames from "classnames/bind";
 import styles from "./barCharts.module.scss";
-import { clamp } from "./utils";
+import { clamp, normalizeClosedDomain } from "./utils";
 
 type StatementStatistics = protos.cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
 const cx = classNames.bind(styles);
@@ -33,9 +33,10 @@ export function latencyBreakdown(s: StatementStatistics) {
   );
 
   const format = (v: number) => Duration(v * 1e9);
+  const domain = normalizeClosedDomain([0, max]);
 
   const scale = scaleLinear()
-    .domain([0, max])
+    .domain(domain)
     .range([0, 100]);
 
   return {

--- a/src/barCharts/rowsBrealdown.ts
+++ b/src/barCharts/rowsBrealdown.ts
@@ -1,6 +1,6 @@
 import { scaleLinear } from "d3-scale";
 import { stdDevLong } from "src/util/appStats";
-import { formatTwoPlaces } from "./utils";
+import { formatTwoPlaces, normalizeClosedDomain } from "./utils";
 import * as protos from "@cockroachlabs/crdb-protobuf-client";
 
 type StatementStatistics = protos.cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
@@ -8,9 +8,10 @@ type StatementStatistics = protos.cockroach.server.serverpb.StatementsResponse.I
 export function rowsBreakdown(s: StatementStatistics) {
   const mean = s.stats.num_rows.mean;
   const sd = stdDevLong(s.stats.num_rows, s.stats.count);
+  const domain = normalizeClosedDomain([0, mean + sd]);
 
   const scale = scaleLinear()
-    .domain([0, mean + sd])
+    .domain(domain)
     .range([0, 100]);
 
   return {

--- a/src/barCharts/utils.spec.ts
+++ b/src/barCharts/utils.spec.ts
@@ -1,0 +1,14 @@
+import { assert } from "chai";
+import { normalizeClosedDomain } from "./utils";
+
+describe("barCharts utils", () => {
+  describe("normalizeClosedDomain", () => {
+    it("returns input args if domain values are not equal", () => {
+      assert.deepStrictEqual(normalizeClosedDomain([10, 15]), [10, 15]);
+    });
+
+    it("returns increased end range by 1 if input start and end values are equal", () => {
+      assert.deepStrictEqual(normalizeClosedDomain([10, 10]), [10, 11]);
+    });
+  });
+});

--- a/src/barCharts/utils.ts
+++ b/src/barCharts/utils.ts
@@ -36,3 +36,20 @@ export function approximify(value: number) {
 
   return "" + Math.round(value);
 }
+
+/**
+ * normalizeClosedDomain increases collapsed domain when start and end range are equal.
+ * @description
+ * This function preserves behavior introduced by following issue in d3-scale library (starting from 2.2 version)
+ * https://github.com/d3/d3-scale/issues/117
+ * It is expected for scaling withing closed domain range, the start value is returned.
+ * @example
+ * scaleLinear().domain([0, 0])(0) // --> 0.5
+ * scaleLinear().domain(normalizeClosedDomain([0, 0]))(0) // --> 0
+ */
+export function normalizeClosedDomain([d0, d1]: Tuple<number>): Tuple<number> {
+  if (d0 === d1) {
+    return [d0, d1 + 1];
+  }
+  return [d0, d1];
+}

--- a/src/declaration.d.ts
+++ b/src/declaration.d.ts
@@ -12,3 +12,5 @@ type ConstructorType = new (...args: any) => any;
 type FirstConstructorParameter<
   P extends ConstructorType
 > = ConstructorParameters<P>[0];
+
+type Tuple<T> = [T, T];


### PR DESCRIPTION
Resolves #40 

This is a fix for regression that was caused when d3 package was
replaced by d3-scale package and others. Latest version of `d3-scale`
package introduced change related to the issue https://github.com/d3/d3-scale/issues/117
that caused to half fill barChart for 0 value.

Now, `normalizeClosedDomain` checks if domain start and end values
are equal or not, and in case they are equal, it increases last value
by one. Note, it doesn't change actual values, but only domain range of
possible values.

Most of the time barChart renders bars with range from 0% to 100% and
it should show 0% value when we have values [0, 0].
- With introduced "breaking" change in d3-scale, it returns middle point
for range [0, 0] and it equals 50% (for range0 from % to 100%).
- With fix and as it was before, for 0 value scaling within [0, 0] domain
will return 0%