### PR TITLE
ui: update links on transactions page documentation

### DIFF
--- a/src/transactionsPage/emptyTransactionsPlaceholder.tsx
+++ b/src/transactionsPage/emptyTransactionsPlaceholder.tsx
@@ -1,16 +1,15 @@
 import React from "react";
 import { EmptyTable, EmptyTableProps } from "../empty";
 import { Anchor } from "../anchor";
-import { statementsTable } from "../util";
+import { transactionsTable } from "../util";
 import magnifyingGlassImg from "../assets/emptyState/magnifying-glass.svg";
 import emptyTableResultsImg from "../assets/emptyState/empty-table-results.svg";
 
 export const EmptyTransactionsPlaceholder: React.FC<{
   isEmptySearchResults: boolean;
 }> = ({ isEmptySearchResults }) => {
-  // TODO (koorosh): Provide appropriate links on Transactions Page documentation
   const footer = (
-    <Anchor href={statementsTable} target="_blank">
+    <Anchor href={transactionsTable} target="_blank">
       Learn more about statements
     </Anchor>
   );

--- a/src/util/docs.ts
+++ b/src/util/docs.ts
@@ -69,3 +69,4 @@ export const enterpriseLicensing =
 
 // Not actually a docs URL.
 export const startTrial = "https://www.cockroachlabs.com/pricing/start-trial/";
+export const transactionsTable = docsURL("ui-transactions-page.html");


### PR DESCRIPTION
Replace stub link (pointed on statements docs) with correct one that
points to transactions page documentation