### PR TITLE
fix assignment of env variables in Github workflow

### DIFF
--- a/.github/workflows/publish-admin-ui-components.yml
+++ b/.github/workflows/publish-admin-ui-components.yml
@@ -30,10 +30,10 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies
         run: yarn install
-      - name: Set github email
-        run: echo '::set-env name=GITHUB_EMAIL::$(git show -s --format='%ae' HEAD)'
-      - name: Set github name
-        run: echo '::set-env name=GITHUB_NAME::$(git show -s --format='%an' HEAD)'
+      - name: Store github user name and email in ENV variables
+        run: |
+          echo "GITHUB_EMAIL=$(git show -s --format='%ae' HEAD)" >> $GITHUB_ENV
+          echo "GITHUB_NAME=$(git show -s --format='%an' HEAD)" >> $GITHUB_ENV
       - name: Configure Git User
         run: |
           git config user.name "${{ env.GITHUB_NAME }}"


### PR DESCRIPTION
This change fixes Github workflow use of `set-env` which is now
deprecated by Github (as explained here https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/)

Now, env variables are set as before, with use of new environment
files in Github workflows.

Initial issue:
<img width="1065" alt="Screen Shot 2020-11-24 at 7 23 27 PM" src="https://user-images.githubusercontent.com/3106437/100129706-8e23af80-2e8a-11eb-94e5-d02cce616d4d.png">
