### PR TITLE
directly set base path for API requests

### DIFF
--- a/src/api/basePath.ts
+++ b/src/api/basePath.ts
@@ -1,0 +1,5 @@
+let path = "";
+
+export const setBasePath = (basePath: string) => (path = basePath);
+
+export const getBasePath = () => path;

--- a/src/api/fetchData.ts
+++ b/src/api/fetchData.ts
@@ -1,5 +1,6 @@
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { RequestError } from "../util";
+import { getBasePath } from "./basePath";
 
 interface ProtoBuilder<
   P extends ConstructorType,
@@ -45,8 +46,9 @@ export const fetchData = <P extends ProtoBuilder<P>, T extends ProtoBuilder<T>>(
     params.method = "POST";
     params.body = toArrayBuffer(encodedRequest);
   }
+  const basePath = getBasePath();
 
-  return fetch(path, params)
+  return fetch(`${basePath}${path}`, params)
     .then(response => {
       if (!response.ok) {
         return response.arrayBuffer().then(buffer => {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,3 +1,4 @@
 export * from "./fetchData";
 export * from "./statementDiagnosticsApi";
 export * from "./statementsApi";
+export * from "./basePath";

--- a/src/api/statementsApi.ts
+++ b/src/api/statementsApi.ts
@@ -3,11 +3,9 @@ import { fetchData } from "src/api";
 
 const STATEMENTS_PATH = "/_status/statements";
 
-export const getStatements = (
-  basePath = "",
-): Promise<cockroach.server.serverpb.StatementsResponse> => {
+export const getStatements = (): Promise<cockroach.server.serverpb.StatementsResponse> => {
   return fetchData(
     cockroach.server.serverpb.StatementsResponse,
-    `${basePath}${STATEMENTS_PATH}`,
+    STATEMENTS_PATH,
   );
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import "antd/dist/antd.less";
 import "./protobufInit";
 import * as util from "./util";
+import * as api from "./api";
 export * from "./anchor";
 export * from "./badge";
 export * from "./barCharts";
@@ -22,4 +23,4 @@ export * from "./transactionsPage";
 export * from "./text";
 export * from "./tooltip";
 export * from "./tooltip2";
-export { util };
+export { util, api };

--- a/src/store/sagas.ts
+++ b/src/store/sagas.ts
@@ -4,10 +4,10 @@ import { localStorageSaga } from "./localStorage";
 import { statementsDiagnosticsSagas } from "./statementDiagnostics";
 import { statementsSaga } from "./statements";
 
-export function* sagas(cacheInvalidationPeriod?: number, apiBasePath?: string) {
+export function* sagas(cacheInvalidationPeriod?: number) {
   yield all([
     fork(localStorageSaga),
-    fork(statementsSaga, cacheInvalidationPeriod, apiBasePath),
+    fork(statementsSaga, cacheInvalidationPeriod),
     fork(statementsDiagnosticsSagas, cacheInvalidationPeriod),
   ]);
 }

--- a/src/store/statements/statements.sagas.spec.ts
+++ b/src/store/statements/statements.sagas.spec.ts
@@ -1,4 +1,4 @@
-import { expectSaga, testSaga } from "redux-saga-test-plan";
+import { expectSaga } from "redux-saga-test-plan";
 import { throwError } from "redux-saga-test-plan/providers";
 import * as matchers from "redux-saga-test-plan/matchers";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
@@ -51,14 +51,6 @@ describe("StatementsPage sagas", () => {
           valid: false,
         })
         .run();
-    });
-
-    it("accepts custom apiPath as an argument for statements api", () => {
-      const customBasePath = "customBasePath";
-      testSaga(requestStatementsSaga, customBasePath)
-        .next()
-        .call(getStatements, customBasePath)
-        .finish();
     });
   });
 

--- a/src/store/statements/statements.sagas.ts
+++ b/src/store/statements/statements.sagas.ts
@@ -8,9 +8,9 @@ export function* refreshStatementsSaga() {
   yield put(actions.request());
 }
 
-export function* requestStatementsSaga(apiBasePath: string) {
+export function* requestStatementsSaga() {
   try {
-    const result = yield call(getStatements, apiBasePath);
+    const result = yield call(getStatements);
     yield put(actions.received(result));
   } catch (e) {
     yield put(actions.failed(e));
@@ -24,7 +24,6 @@ export function* receivedStatementsSaga(delayMs: number) {
 
 export function* statementsSaga(
   cacheInvalidationPeriod: number = CACHE_INVALIDATION_PERIOD,
-  apiBasePath: string = undefined,
 ) {
   yield all([
     throttleWithReset(
@@ -33,7 +32,7 @@ export function* statementsSaga(
       [actions.invalidated, actions.failed],
       refreshStatementsSaga,
     ),
-    takeLatest(actions.request, requestStatementsSaga, apiBasePath),
+    takeLatest(actions.request, requestStatementsSaga),
     takeLatest(
       actions.received,
       receivedStatementsSaga,


### PR DESCRIPTION
With new requirements, base path for api calls can be arbitrary and
might not rely on browser's path or whatever.
This change implements getter/setter functions to directly set
base path which is needed to use for api requests.

Also it simplifies and eliminates passing basePath as extra
argument through sagas.